### PR TITLE
Remove RBAC for the deployment user

### DIFF
--- a/locals.byor.tf
+++ b/locals.byor.tf
@@ -17,11 +17,11 @@ locals {
   #################################################################
   # Key Vault specific local variables
   #################################################################
-  key_vault_default_role_assignments = {
-    deployment_user_secrets = {
-      role_definition_id_or_name = "Key Vault Administrator"
-      principal_id               = data.azurerm_client_config.current.object_id
-    }
+  key_vault_default_role_assignments = { #TODO cleanup the deployment user comments after testing.
+    #deployment_user_secrets = {
+    #  role_definition_id_or_name = "Key Vault Administrator"
+    #  principal_id               = data.azurerm_client_config.current.object_id
+    #}
   }
   #key_vault_name = try(var.key_vault_definition.name, null) != null ? var.key_vault_definition.name : (try(var.base_name, null) != null ? "${var.base_name}-kv-${random_string.resource_token.result}" : "kv-fndry-${random_string.resource_token.result}")
   key_vault_role_assignments = { for k, v in var.key_vault_definition : k => merge(
@@ -39,22 +39,22 @@ locals {
   #region_zones_lookup          = [for region in module.avm_utl_regions.regions : region if(lower(region.name) == lower(var.location) || (lower(region.display_name) == lower(var.location)))][0].zones
   resource_group_name = basename(var.resource_group_resource_id) #assumes resource group id is required.
   storage_account_default_role_assignments = {
-    deployment_user_blob = {
-      role_definition_id_or_name = "Storage Blob Data Owner"
-      principal_id               = data.azurerm_client_config.current.object_id
-    }
-    deployment_user_file = {
-      role_definition_id_or_name = "Storage File Data Privileged Contributor"
-      principal_id               = data.azurerm_client_config.current.object_id
-    }
-    deployment_user_queue = {
-      role_definition_id_or_name = "Storage Queue Data Contributor"
-      principal_id               = data.azurerm_client_config.current.object_id
-    }
-    deployment_user_table = {
-      role_definition_id_or_name = "Storage Table Data Contributor"
-      principal_id               = data.azurerm_client_config.current.object_id
-    }
+    #deployment_user_blob = {
+    #  role_definition_id_or_name = "Storage Blob Data Owner"
+    #  principal_id               = data.azurerm_client_config.current.object_id
+    #}
+    #deployment_user_file = {
+    #  role_definition_id_or_name = "Storage File Data Privileged Contributor"
+    #  principal_id               = data.azurerm_client_config.current.object_id
+    #}
+    #deployment_user_queue = {
+    #  role_definition_id_or_name = "Storage Queue Data Contributor"
+    #  principal_id               = data.azurerm_client_config.current.object_id
+    #}
+    #deployment_user_table = {
+    #  role_definition_id_or_name = "Storage Table Data Contributor"
+    #  principal_id               = data.azurerm_client_config.current.object_id
+    #}
   }
   #################################################################
   # Storage Account specific local variables

--- a/locals.foundry.tf
+++ b/locals.foundry.tf
@@ -1,5 +1,6 @@
 locals {
   foundry_default_role_assignments = {
+    /*
     deployment_user_cognitive_services_user = {
       role_definition_id_or_name             = "Cognitive Services User"
       principal_id                           = data.azurerm_client_config.current.object_id
@@ -9,6 +10,7 @@ locals {
       delegated_managed_identity_resource_id = null
       principal_type                         = null
     }
+    */
   }
   foundry_role_assignments = merge(
     local.foundry_default_role_assignments,


### PR DESCRIPTION
## Description

Removes the deployment user static RBAC entries that were feedback from users.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
