### PR TITLE
move sleep and purge actions from examples to main.foundry.tf for vnet deletion

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,20 @@
 {
   "image": "mcr.microsoft.com/azterraform:avm-latest",
+  "containerEnv": {
+    "AVM_IN_CONTAINER": "true"
+  },
   "updateRemoteUserUID": true,
-  "runArgs": [],
-  "mounts": [],
-  "onCreateCommand": "terraform || true",
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--init",
+    "--network=host"
+  ],
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ],
+  "onCreateCommand": "terraform version",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,6 +146,7 @@ terraform validate
 # AVM-specific validation (MANDATORY)
 export PORCH_NO_TUI=1
 ./avm pre-commit
+<commit any changes>
 ./avm pr-check
 ```
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  "editor.bracketPairColorization.enabled": true,
-  "editor.tabSize": 2,
-  "files.eol": "\n"
+  "chat.agent.maxRequests": 500,
+  "chat.math.enabled": true,
+  "chat.todoListTool.enabled": true,
+  "github.copilot.chat.agent.thinkingTool": true
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ terraform validate
 # AVM-specific validation (MANDATORY)
 export PORCH_NO_TUI=1
 ./avm pre-commit
+<commit any changes>
 ./avm pr-check
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 
+- <a name="requirement_time"></a> [time](#requirement\_time) (~> 0.12)
+
 ## Resources
 
 The following resources are used by this module:
@@ -158,6 +160,7 @@ The following resources are used by this module:
 - [azapi_resource.ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.ai_model_deployment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.ai_search](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource_action.purge_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azurerm_monitor_diagnostic_setting.this_aisearch](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
 - [azurerm_private_endpoint.ai_foundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
 - [azurerm_private_endpoint.pe_aisearch](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
@@ -166,6 +169,7 @@ The following resources are used by this module:
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_string.resource_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
+- [time_sleep.purge_ai_foundry_cooldown](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -33,10 +33,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -44,10 +40,6 @@ terraform {
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.12"
     }
   }
 }
@@ -62,8 +54,6 @@ provider "azurerm" {
     }
   }
 }
-
-data "azurerm_client_config" "current" {}
 
 locals {
   base_name = "basic"
@@ -129,23 +119,6 @@ module "ai_foundry" {
   }
   create_byor              = false # default: false
   create_private_endpoints = false # default: false
-
-  depends_on = [azapi_resource_action.purge_ai_foundry]
-}
-
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
-
-  depends_on = [time_sleep.purge_ai_foundry_cooldown]
-}
-
-resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "300s" # 5m
-
-  depends_on = [azurerm_resource_group.this]
 }
 ```
 
@@ -156,23 +129,16 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
-
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
-
-- <a name="requirement_time"></a> [time](#requirement\_time) (~> 0.12)
 
 ## Resources
 
 The following resources are used by this module:
 
-- [azapi_resource_action.purge_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [random_shuffle.locations](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/shuffle) (resource)
-- [time_sleep.purge_ai_foundry_cooldown](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
-- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -13,10 +9,6 @@ terraform {
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.12"
     }
   }
 }
@@ -99,20 +91,4 @@ module "ai_foundry" {
   create_byor              = false # default: false
   create_private_endpoints = false # default: false
 
-  depends_on = [azapi_resource_action.purge_ai_foundry]
-}
-
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
-
-  depends_on = [time_sleep.purge_ai_foundry_cooldown]
-}
-
-resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "300s" # 5m
-
-  depends_on = [azurerm_resource_group.this]
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -88,5 +88,4 @@ module "ai_foundry" {
   }
   create_byor              = false # default: false
   create_private_endpoints = false # default: false
-
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -24,8 +24,6 @@ provider "azurerm" {
   }
 }
 
-data "azurerm_client_config" "current" {}
-
 locals {
   base_name = "basic"
 }

--- a/examples/standard-private-byor/README.md
+++ b/examples/standard-private-byor/README.md
@@ -113,10 +113,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.12"
-    }
   }
 }
 
@@ -660,24 +656,9 @@ module "ai_foundry" {
       enable_diagnostic_settings = false
     }
   }
-
-  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
 
-  depends_on = [time_sleep.purge_ai_foundry_cooldown]
-}
-
-resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "900s" # 10m
-
-  depends_on = [azurerm_subnet.agent_services]
-}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -693,14 +674,11 @@ The following requirements are needed by this module:
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 
-- <a name="requirement_time"></a> [time](#requirement\_time) (~> 0.12)
-
 ## Resources
 
 The following resources are used by this module:
 
 - [azapi_resource.ai_search](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
-- [azapi_resource_action.purge_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azurerm_log_analytics_workspace.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) (resource)
 - [azurerm_private_dns_zone.ai_services](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)
 - [azurerm_private_dns_zone.cognitiveservices](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)
@@ -727,7 +705,6 @@ The following resources are used by this module:
 - [azurerm_subnet.vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) (resource)
 - [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
 - [random_shuffle.locations](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/shuffle) (resource)
-- [time_sleep.purge_ai_foundry_cooldown](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->

--- a/examples/standard-private-byor/main.tf
+++ b/examples/standard-private-byor/main.tf
@@ -557,7 +557,6 @@ module "ai_foundry" {
       enable_diagnostic_settings = false
     }
   }
-
 }
 
 

--- a/examples/standard-private-byor/main.tf
+++ b/examples/standard-private-byor/main.tf
@@ -14,10 +14,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.12"
-    }
   }
 }
 
@@ -562,20 +558,6 @@ module "ai_foundry" {
     }
   }
 
-  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
 
-  depends_on = [time_sleep.purge_ai_foundry_cooldown]
-}
-
-resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "900s" # 10m
-
-  depends_on = [azurerm_subnet.agent_services]
-}

--- a/examples/standard-private/README.md
+++ b/examples/standard-private/README.md
@@ -452,27 +452,12 @@ module "ai_foundry" {
   }
 }
 
-# Explicitly remove service association links before subnet deletion
-resource "azapi_resource_action" "cleanup_service_association_links" {
-  method      = "DELETE"
-  resource_id = azurerm_subnet.agent_services.id
-  type        = "Microsoft.Network/virtualNetworks/subnets@2023-04-01"
-  body = jsonencode({
-    properties = {
-      serviceAssociationLinks = []
-    }
-  })
-  when = "destroy"
-
-  depends_on = [module.ai_foundry]
-}
-
 # Update the time_sleep to depend on the cleanup action
 resource "time_sleep" "agent_services_deletion_wait" {
   destroy_duration = "300s" # 5 minutes
 
   depends_on = [
-    azapi_resource_action.cleanup_service_association_links,
+    module.ai_foundry,
     azurerm_subnet.agent_services
   ]
 }
@@ -497,7 +482,6 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_resource_action.cleanup_service_association_links](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azurerm_private_dns_zone.ai_services](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)
 - [azurerm_private_dns_zone.cognitiveservices](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)
 - [azurerm_private_dns_zone.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)

--- a/examples/standard-private/README.md
+++ b/examples/standard-private/README.md
@@ -90,6 +90,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.12"
+    }
   }
 }
 
@@ -225,6 +229,8 @@ resource "azurerm_private_dns_zone_virtual_network_link" "cosmosdb" {
   private_dns_zone_name = azurerm_private_dns_zone.cosmosdb.name
   resource_group_name   = azurerm_resource_group.this.name
   virtual_network_id    = azurerm_virtual_network.this.id
+
+  depends_on = [time_sleep.agent_services_deletion_wait]
 }
 
 # AI Search Private DNS Zone
@@ -441,6 +447,12 @@ module "ai_foundry" {
     }
   }
 }
+
+resource "time_sleep" "agent_services_deletion_wait" {
+  destroy_duration = "180s" # 3 minutes wait
+
+  depends_on = [azurerm_subnet.agent_services]
+}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -453,6 +465,8 @@ The following requirements are needed by this module:
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+- <a name="requirement_time"></a> [time](#requirement\_time) (~> 0.12)
 
 ## Resources
 
@@ -482,6 +496,7 @@ The following resources are used by this module:
 - [azurerm_subnet.vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) (resource)
 - [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
 - [random_shuffle.locations](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/shuffle) (resource)
+- [time_sleep.agent_services_deletion_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/standard-private/README.md
+++ b/examples/standard-private/README.md
@@ -82,10 +82,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -469,8 +465,6 @@ resource "time_sleep" "agent_services_deletion_wait" {
 The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
-
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/standard-private/README.md
+++ b/examples/standard-private/README.md
@@ -82,10 +82,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -93,10 +89,6 @@ terraform {
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.12"
     }
   }
 }
@@ -115,9 +107,6 @@ provider "azurerm" {
     }
   }
 }
-
-# Get current subscription data
-data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
@@ -353,6 +342,7 @@ module "virtual_machine" {
   admin_username                                         = "azureadmin"
   bypass_platform_safety_checks_on_user_schedule_enabled = false
   disable_password_authentication                        = false
+  encryption_at_host_enabled                             = false
   os_disk = {
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
@@ -450,25 +440,7 @@ module "ai_foundry" {
       }
     }
   }
-
-  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
-
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
-
-  depends_on = [time_sleep.purge_ai_foundry_cooldown]
-}
-
-resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "900s" # 10m
-
-  depends_on = [azurerm_subnet.agent_services]
-}
-
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -478,19 +450,14 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
-
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
-
-- <a name="requirement_time"></a> [time](#requirement\_time) (~> 0.12)
 
 ## Resources
 
 The following resources are used by this module:
 
-- [azapi_resource_action.purge_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azurerm_private_dns_zone.ai_services](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)
 - [azurerm_private_dns_zone.cognitiveservices](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)
 - [azurerm_private_dns_zone.cosmosdb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)
@@ -515,8 +482,6 @@ The following resources are used by this module:
 - [azurerm_subnet.vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) (resource)
 - [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
 - [random_shuffle.locations](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/shuffle) (resource)
-- [time_sleep.purge_ai_foundry_cooldown](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
-- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/standard-private/README.md
+++ b/examples/standard-private/README.md
@@ -90,10 +90,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.12"
-    }
   }
 }
 
@@ -447,16 +443,6 @@ module "ai_foundry" {
     }
   }
 }
-
-# Update the time_sleep to depend on the cleanup action
-resource "time_sleep" "agent_services_deletion_wait" {
-  destroy_duration = "300s" # 5 minutes
-
-  depends_on = [
-    module.ai_foundry,
-    azurerm_subnet.agent_services
-  ]
-}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -469,8 +455,6 @@ The following requirements are needed by this module:
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
-
-- <a name="requirement_time"></a> [time](#requirement\_time) (~> 0.12)
 
 ## Resources
 
@@ -500,7 +484,6 @@ The following resources are used by this module:
 - [azurerm_subnet.vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) (resource)
 - [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
 - [random_shuffle.locations](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/shuffle) (resource)
-- [time_sleep.agent_services_deletion_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/standard-private/README.md
+++ b/examples/standard-private/README.md
@@ -225,8 +225,6 @@ resource "azurerm_private_dns_zone_virtual_network_link" "cosmosdb" {
   private_dns_zone_name = azurerm_private_dns_zone.cosmosdb.name
   resource_group_name   = azurerm_resource_group.this.name
   virtual_network_id    = azurerm_virtual_network.this.id
-
-  depends_on = [time_sleep.agent_services_deletion_wait]
 }
 
 # AI Search Private DNS Zone

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -28,9 +28,6 @@ provider "azurerm" {
   }
 }
 
-# Get current subscription data
-data "azurerm_client_config" "current" {}
-
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.5.2"
@@ -365,5 +362,3 @@ module "ai_foundry" {
   }
 
 }
-
-

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -374,16 +374,15 @@ module "ai_foundry" {
 
 # Explicitly remove service association links before subnet deletion
 resource "azapi_resource_action" "cleanup_service_association_links" {
-  type        = "Microsoft.Network/virtualNetworks/subnets@2023-04-01"
-  resource_id = azurerm_subnet.agent_services.id
   method      = "DELETE"
-  when        = "destroy"
-  
+  resource_id = azurerm_subnet.agent_services.id
+  type        = "Microsoft.Network/virtualNetworks/subnets@2023-04-01"
   body = jsonencode({
     properties = {
       serviceAssociationLinks = []
     }
   })
+  when = "destroy"
 
   depends_on = [module.ai_foundry]
 }

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -369,8 +369,7 @@ module "ai_foundry" {
 }
 
 resource "time_sleep" "agent_services_deletion_wait" {
-  destroy_duration = "180s" # 3 minutes wait before deletion
+  destroy_duration = "180s" # 3 minutes wait
 
-  # This resource will be destroyed before the subnet
   depends_on = [azurerm_subnet.agent_services]
 }

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -372,27 +372,12 @@ module "ai_foundry" {
   }
 }
 
-# Explicitly remove service association links before subnet deletion
-resource "azapi_resource_action" "cleanup_service_association_links" {
-  method      = "DELETE"
-  resource_id = azurerm_subnet.agent_services.id
-  type        = "Microsoft.Network/virtualNetworks/subnets@2023-04-01"
-  body = jsonencode({
-    properties = {
-      serviceAssociationLinks = []
-    }
-  })
-  when = "destroy"
-
-  depends_on = [module.ai_foundry]
-}
-
 # Update the time_sleep to depend on the cleanup action
 resource "time_sleep" "agent_services_deletion_wait" {
   destroy_duration = "300s" # 5 minutes
 
   depends_on = [
-    azapi_resource_action.cleanup_service_association_links,
+    module.ai_foundry,
     azurerm_subnet.agent_services
   ]
 }

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.12"
+    }
   }
 }
 
@@ -145,6 +149,8 @@ resource "azurerm_private_dns_zone_virtual_network_link" "cosmosdb" {
   private_dns_zone_name = azurerm_private_dns_zone.cosmosdb.name
   resource_group_name   = azurerm_resource_group.this.name
   virtual_network_id    = azurerm_virtual_network.this.id
+
+  depends_on = [time_sleep.agent_services_deletion_wait]
 }
 
 # AI Search Private DNS Zone
@@ -360,4 +366,11 @@ module "ai_foundry" {
       }
     }
   }
+}
+
+resource "time_sleep" "agent_services_deletion_wait" {
+  destroy_duration = "180s" # 3 minutes wait before deletion
+
+  # This resource will be destroyed before the subnet
+  depends_on = [azurerm_subnet.agent_services]
 }

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.12"
-    }
   }
 }
 
@@ -366,14 +362,4 @@ module "ai_foundry" {
       }
     }
   }
-}
-
-# Update the time_sleep to depend on the cleanup action
-resource "time_sleep" "agent_services_deletion_wait" {
-  destroy_duration = "300s" # 5 minutes
-
-  depends_on = [
-    module.ai_foundry,
-    azurerm_subnet.agent_services
-  ]
 }

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -13,10 +9,6 @@ terraform {
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.12"
     }
   }
 }
@@ -273,6 +265,7 @@ module "virtual_machine" {
   admin_username                                         = "azureadmin"
   bypass_platform_safety_checks_on_user_schedule_enabled = false
   disable_password_authentication                        = false
+  encryption_at_host_enabled                             = false
   os_disk = {
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
@@ -371,21 +364,6 @@ module "ai_foundry" {
     }
   }
 
-  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
-
-  depends_on = [time_sleep.purge_ai_foundry_cooldown]
-}
-
-resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "900s" # 10m
-
-  depends_on = [azurerm_subnet.agent_services]
-}
 

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -145,8 +145,6 @@ resource "azurerm_private_dns_zone_virtual_network_link" "cosmosdb" {
   private_dns_zone_name = azurerm_private_dns_zone.cosmosdb.name
   resource_group_name   = azurerm_resource_group.this.name
   virtual_network_id    = azurerm_virtual_network.this.id
-
-  depends_on = [time_sleep.agent_services_deletion_wait]
 }
 
 # AI Search Private DNS Zone

--- a/examples/standard-private/main.tf
+++ b/examples/standard-private/main.tf
@@ -360,5 +360,4 @@ module "ai_foundry" {
       }
     }
   }
-
 }

--- a/examples/standard-public-byor/README.md
+++ b/examples/standard-public-byor/README.md
@@ -318,15 +318,6 @@ module "ai_foundry" {
       enable_diagnostic_settings = false
     }
   }
-
-  depends_on = [azapi_resource_action.purge_ai_foundry]
-}
-
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
 }
 ```
 
@@ -348,7 +339,6 @@ The following requirements are needed by this module:
 The following resources are used by this module:
 
 - [azapi_resource.ai_search](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
-- [azapi_resource_action.purge_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azurerm_log_analytics_workspace.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [random_shuffle.locations](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/shuffle) (resource)

--- a/examples/standard-public-byor/main.tf
+++ b/examples/standard-public-byor/main.tf
@@ -244,12 +244,4 @@ module "ai_foundry" {
     }
   }
 
-  depends_on = [azapi_resource_action.purge_ai_foundry]
-}
-
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
 }

--- a/examples/standard-public-byor/main.tf
+++ b/examples/standard-public-byor/main.tf
@@ -243,5 +243,4 @@ module "ai_foundry" {
       enable_diagnostic_settings = false
     }
   }
-
 }

--- a/examples/standard-public/README.md
+++ b/examples/standard-public/README.md
@@ -77,10 +77,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -103,8 +99,6 @@ provider "azurerm" {
     }
   }
 }
-
-data "azurerm_client_config" "current" {}
 
 locals {
   base_name = "public"
@@ -207,16 +201,8 @@ module "ai_foundry" {
       enable_diagnostic_settings = false
     }
   }
-
-  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
-}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -226,8 +212,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
-
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
@@ -236,11 +220,9 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_resource_action.purge_ai_foundry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
 - [azurerm_log_analytics_workspace.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [random_shuffle.locations](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/shuffle) (resource)
-- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/standard-public/main.tf
+++ b/examples/standard-public/main.tf
@@ -25,8 +25,6 @@ provider "azurerm" {
   }
 }
 
-data "azurerm_client_config" "current" {}
-
 locals {
   base_name = "public"
 }

--- a/examples/standard-public/main.tf
+++ b/examples/standard-public/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.0"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -132,13 +128,5 @@ module "ai_foundry" {
       enable_diagnostic_settings = false
     }
   }
-
-  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
-resource "azapi_resource_action" "purge_ai_foundry" {
-  method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
-  when        = "destroy"
-}

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -34,8 +34,6 @@ resource "azapi_resource" "ai_foundry" {
   schema_validation_enabled = false
   tags                      = var.tags
   update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-
-  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
 
@@ -136,4 +134,10 @@ resource "azapi_resource_action" "purge_ai_foundry" {
 
 resource "time_sleep" "purge_ai_foundry_cooldown" {
   destroy_duration = "600s" # 10m
+
+  depends_on = [
+    azapi_resource.ai_foundry,
+    azapi_resource.ai_agent_capability_host,
+    azapi_resource.ai_model_deployment
+  ]
 }

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -34,6 +34,8 @@ resource "azapi_resource" "ai_foundry" {
   schema_validation_enabled = false
   tags                      = var.tags
   update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  depends_on = [ azapi_resource_action.purge_ai_foundry ]
 }
 
 
@@ -121,4 +123,17 @@ resource "azurerm_role_assignment" "foundry_role_assignments" {
   role_definition_id                     = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_definition_id_or_name : null
   role_definition_name                   = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_definition_id_or_name
   skip_service_principal_aad_check       = each.value.skip_service_principal_aad_check
+}
+
+resource "azapi_resource_action" "purge_ai_foundry" {
+  method      = "DELETE"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${var.location}/resourceGroups/${basename(var.resource_group_resource_id)}/deletedAccounts/${local.ai_foundry_name}"
+  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
+  when        = "destroy"
+
+  depends_on = [time_sleep.purge_ai_foundry_cooldown]
+}
+
+resource "time_sleep" "purge_ai_foundry_cooldown" {
+  destroy_duration = "600s" # 10m
 }

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -34,6 +34,8 @@ resource "azapi_resource" "ai_foundry" {
   schema_validation_enabled = false
   tags                      = var.tags
   update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
 
@@ -133,11 +135,5 @@ resource "azapi_resource_action" "purge_ai_foundry" {
 }
 
 resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "600s" # 10m
-
-  depends_on = [
-    azapi_resource.ai_foundry,
-    azapi_resource.ai_agent_capability_host,
-    azapi_resource.ai_model_deployment
-  ]
+  destroy_duration = "900s" # 15m
 }

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -35,7 +35,7 @@ resource "azapi_resource" "ai_foundry" {
   tags                      = var.tags
   update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
-  depends_on = [ azapi_resource_action.purge_ai_foundry ]
+  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -18,5 +18,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.7"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.12"
+    }
   }
 }


### PR DESCRIPTION


## Description

move sleep and purge actions from examples to main.foundry.tf for vnet deletion


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
