### PR TITLE
dependencies/role-assignments: explicitly set principal_type

### DIFF
--- a/modules/ai-foundry-project/dependent-resource-rbac.tf
+++ b/modules/ai-foundry-project/dependent-resource-rbac.tf
@@ -30,6 +30,7 @@ resource "azurerm_role_assignment" "ai_search_role_assignments" {
   scope        = var.create_project_connections ? var.ai_search_id : "/n/o/t/u/s/e/d"
   #name                 = each.key
   role_definition_name = each.value.role_definition_id_or_name
+  principal_type       = "ServicePrincipal"
 
   depends_on = [time_sleep.wait_project_identities]
 }
@@ -41,6 +42,7 @@ resource "azurerm_role_assignment" "cosmosdb_role_assignments" {
   scope        = var.create_project_connections ? var.cosmos_db_id : "/n/o/t/u/s/e/d"
   #name                 = each.key
   role_definition_name = each.value.role_definition_id_or_name
+  principal_type       = "ServicePrincipal"
 
   depends_on = [time_sleep.wait_project_identities]
 }
@@ -53,6 +55,7 @@ resource "azurerm_role_assignment" "storage_role_assignments" {
   scope        = var.create_project_connections ? var.storage_account_id : "/n/o/t/u/s/e/d"
   #name                 = each.key
   role_definition_name = each.value.role_definition_id_or_name
+  principal_type       = "ServicePrincipal"
 
   depends_on = [time_sleep.wait_project_identities]
 }
@@ -128,6 +131,7 @@ resource "azurerm_role_assignment" "storage_blob_data_owner" {
   condition_version    = "2.0"
   name                 = uuidv5("dns", "${azapi_resource.ai_foundry_project.name}${azapi_resource.ai_foundry_project.output.identity.principalId}${basename(var.create_project_connections ? var.storage_account_id : "/n/o/t/u/s/e/d")}storageblobdataowner")
   role_definition_name = "Storage Blob Data Owner"
+  principal_type       = "ServicePrincipal"
 
   depends_on = [
     azapi_resource.ai_agent_capability_host


### PR DESCRIPTION
## Description

Explicitly sets principal_type on azurerm_role_assignment resources. The role assignments are all hard coded to use the managed identity.
See https://github.com/hashicorp/terraform-provider-azurerm/issues/23364#issuecomment-1893777970 for context why explicitly setting this is necessary in some situations.


<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->