### PR TITLE
security: add AVM telemetry block (wave-2)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,3 +38,17 @@ module "ai_foundry_project" {
     module.storage_account
   ]
 }
+
+resource "modtm_telemetry" "telemetry" {
+  count = var.enable_telemetry ? 1 : 0
+
+  tags = {
+    avm_yor_trace  = "06fcb803-f35a-48ab-bb37-a43cae0e3c2c"
+    avm_git_commit = "f5e67b7c4f7ffd7dfe10cad57f2ca2e949ea97b8"
+    avm_git_file   = "main.tf"
+    avm_git_org    = "Azure"
+    avm_git_repo   = "terraform-azurerm-avm-ptn-aiml-ai-foundry"
+    module_source  = "Azure/avm-ptn-aiml-ai-foundry/azurerm"
+    module_version = "0.10.1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds the required \modtm_telemetry\ resource per [AVM Telemetry Specifications](https://aka.ms/avm/telemetryinfo).

## Changes
- ✅ Added \modtm_telemetry\ resource with count controlled by existing \nable_telemetry\ variable
- ✅ \modtm\ provider already declared in \	erraform.tf\ (~> 0.3)
- ✅ \nable_telemetry\ variable already exists in \ariables.tf\ (default: true)

## Validation
- Terraform formatted (\	erraform fmt\)
- Follows AVM telemetry pattern with module metadata tags

## References
- AVM Telemetry Info: https://aka.ms/avm/telemetryinfo
- Closes finding: \high-add-avm-telemetry-aiml-foundry\ (security audit wave-2)