### PR TITLE
feat: add private_endpoints_manage_dns_zone_group support for AI Foundry

### DIFF
--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -172,7 +172,7 @@ resource "time_sleep" "ai_foundry_wait" {
 }
 
 resource "azurerm_private_endpoint" "ai_foundry" {
-  count = var.create_private_endpoints ? 1 : 0
+  count = var.create_private_endpoints && var.ai_foundry.private_endpoints_manage_dns_zone_group ? 1 : 0
 
   location            = var.location
   name                = "pe-${azapi_resource.ai_foundry.name}"
@@ -186,9 +186,36 @@ resource "azurerm_private_endpoint" "ai_foundry" {
     private_connection_resource_id = azapi_resource.ai_foundry.id
     subresource_names              = ["account"]
   }
-  private_dns_zone_group {
-    name                 = "pe-${azapi_resource.ai_foundry.name}-dns"
-    private_dns_zone_ids = var.ai_foundry.private_dns_zone_resource_ids
+  dynamic "private_dns_zone_group" {
+    for_each = length(var.ai_foundry.private_dns_zone_resource_ids) > 0 ? ["this"] : []
+
+    content {
+      name                 = "pe-${azapi_resource.ai_foundry.name}-dns"
+      private_dns_zone_ids = var.ai_foundry.private_dns_zone_resource_ids
+    }
+  }
+
+  depends_on = [azapi_resource.ai_foundry, time_sleep.ai_foundry_wait]
+}
+
+resource "azurerm_private_endpoint" "ai_foundry_unmanaged_dns_zone_groups" {
+  count = var.create_private_endpoints && !var.ai_foundry.private_endpoints_manage_dns_zone_group ? 1 : 0
+
+  location            = var.location
+  name                = "pe-${azapi_resource.ai_foundry.name}"
+  resource_group_name = basename(var.resource_group_resource_id)
+  subnet_id           = var.private_endpoint_subnet_resource_id
+  tags                = var.tags
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = "psc-${azapi_resource.ai_foundry.name}"
+    private_connection_resource_id = azapi_resource.ai_foundry.id
+    subresource_names              = ["account"]
+  }
+
+  lifecycle {
+    ignore_changes = [private_dns_zone_group]
   }
 
   depends_on = [azapi_resource.ai_foundry, time_sleep.ai_foundry_wait]

--- a/variables.foundry.tf
+++ b/variables.foundry.tf
@@ -9,8 +9,9 @@ variable "ai_foundry" {
       subnetArmId                = string
       useMicrosoftManagedNetwork = optional(bool, false)
     })), null)
-    private_dns_zone_resource_ids = optional(list(string), [])
-    sku                           = optional(string, "S0")
+    private_dns_zone_resource_ids           = optional(list(string), [])
+    private_endpoints_manage_dns_zone_group = optional(bool, true)
+    sku                                     = optional(string, "S0")
     customer_managed_key = optional(object({
       key_vault_resource_id              = string
       key_name                           = string
@@ -40,7 +41,8 @@ Configuration object for the Azure AI Foundry service to be created for AI workl
   - `scenario` - (Optional) The scenario for the network injection. Default is "agent".
   - `subnetArmId` - The subnet ARM ID for the AI agent service.
   - `useMicrosoftManagedNetwork` - (Optional) Whether to use Microsoft managed network for the injection. Default is false.
-- `private_dns_zone_resource_ids` - (Optional) The resource IDs of the existing private DNS zones for AI Foundry. Required when `create_private_endpoints` is true.
+- `private_dns_zone_resource_ids` - (Optional) The resource IDs of the existing private DNS zones for AI Foundry. Required when `create_private_endpoints` is true and `private_endpoints_manage_dns_zone_group` is true.
+- `private_endpoints_manage_dns_zone_group` - (Optional) Whether to manage the private DNS zone group for the AI Foundry private endpoint with this module. Set to `false` when DNS zone groups are managed externally, e.g. via Azure Policy. Default is `true`.
 - `sku` - (Optional) The SKU of the AI Foundry service. Default is "S0".
 - `customer_managed_key` - (Optional) Customer-managed key encryption configuration. Requires a Key Vault with an existing key and a user-assigned managed identity with "Key Vault Crypto User" role on the Key Vault.
   - `key_vault_resource_id` - Resource ID of the Key Vault containing the encryption key.


### PR DESCRIPTION
   Allow callers to opt out of Terraform-managed DNS zone groups on the AI
   Foundry private endpoint, matching the pattern already used by the AI
   Search, Key Vault, CosmosDB, and Storage Account resources in this module.

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
