### PR TITLE
chore(deps): combined Dependabot bumps (naming 0.4.3, avm-utl-regions 0.12.0, storageaccount 0.6.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,7 +871,7 @@ Version:
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 ### <a name="module_cosmosdb"></a> [cosmosdb](#module\_cosmosdb)
 
@@ -889,7 +889,7 @@ Version: 0.10.2
 
 Source: Azure/avm-res-storage-storageaccount/azurerm
 
-Version: 0.6.7
+Version: 0.7.2
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ Description: Configuration object for the Azure Storage Account to be created fo
   - `account_replication_type` - (Optional) The replication type for the storage account. Default is "ZRS".
   - `endpoints` - (Optional) Map of endpoint configurations to enable. Default includes blob endpoint.
     - `type` - The type of endpoint (e.g., "blob", "file", "queue", "table").
-    - `private_dns_zone_resource_id` - (Optional) The resource ID of the existing private DNS zone for the endpoint. If not provided or set to null, no DNS zone group will be created.
+    - `private_dns_zone_resource_ids` - (Optional) The resource IDs of the existing private DNS zones for the endpoint. If not provided, no DNS zone group will be created.
   - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
   - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is false.
   - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
@@ -729,8 +729,8 @@ map(object({
     account_tier             = optional(string, "Standard")
     account_replication_type = optional(string, "ZRS")
     endpoints = optional(map(object({
-      type                         = string
-      private_dns_zone_resource_id = optional(string, null)
+      type                          = string
+      private_dns_zone_resource_ids = optional(set(string), [])
       })), {
       blob = {
         type = "blob"

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ Description: Configuration object for the Azure Storage Account to be created fo
   - `account_replication_type` - (Optional) The replication type for the storage account. Default is "ZRS".
   - `endpoints` - (Optional) Map of endpoint configurations to enable. Default includes blob endpoint.
     - `type` - The type of endpoint (e.g., "blob", "file", "queue", "table").
-    - `private_dns_zone_resource_ids` - (Optional) The resource IDs of the existing private DNS zones for the endpoint. If not provided, no DNS zone group will be created.
+    - `private_dns_zone_resource_id` - (Optional) The resource ID of the existing private DNS zone for the endpoint. If not provided or set to null, no DNS zone group will be created.
   - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
   - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is false.
   - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
@@ -729,8 +729,8 @@ map(object({
     account_tier             = optional(string, "Standard")
     account_replication_type = optional(string, "ZRS")
     endpoints = optional(map(object({
-      type                          = string
-      private_dns_zone_resource_ids = optional(set(string), [])
+      type                         = string
+      private_dns_zone_resource_id = optional(string, null)
       })), {
       blob = {
         type = "blob"
@@ -889,7 +889,7 @@ Version: 0.10.2
 
 Source: Azure/avm-res-storage-storageaccount/azurerm
 
-Version: 0.7.2
+Version: 0.6.9
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/basic-cmk/README.md
+++ b/examples/basic-cmk/README.md
@@ -68,8 +68,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/basic-cmk/README.md
+++ b/examples/basic-cmk/README.md
@@ -66,7 +66,7 @@ locals {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"
@@ -79,7 +79,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5
@@ -258,13 +258,13 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/basic-cmk/main.tf
+++ b/examples/basic-cmk/main.tf
@@ -40,7 +40,7 @@ locals {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"

--- a/examples/basic-cmk/main.tf
+++ b/examples/basic-cmk/main.tf
@@ -53,7 +53,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5

--- a/examples/basic-cmk/main.tf
+++ b/examples/basic-cmk/main.tf
@@ -42,8 +42,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -61,7 +61,7 @@ locals {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"
@@ -74,7 +74,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5
@@ -167,13 +167,13 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -63,8 +63,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -30,7 +30,7 @@ locals {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -43,7 +43,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -32,8 +32,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/private-byor-cmk/README.md
+++ b/examples/private-byor-cmk/README.md
@@ -117,8 +117,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/private-byor-cmk/README.md
+++ b/examples/private-byor-cmk/README.md
@@ -523,11 +523,10 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.7.2"
+  version = "0.6.9"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -539,6 +538,7 @@ module "storage_account" {
       resource_id = azurerm_user_assigned_identity.this.id
     }
   }
+  resource_group_name = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {
@@ -807,7 +807,7 @@ Version: 0.12.0
 
 Source: Azure/avm-res-storage-storageaccount/azurerm
 
-Version: 0.7.2
+Version: 0.6.9
 
 ### <a name="module_virtual_machine"></a> [virtual\_machine](#module\_virtual\_machine)
 

--- a/examples/private-byor-cmk/README.md
+++ b/examples/private-byor-cmk/README.md
@@ -115,7 +115,7 @@ data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"
@@ -132,7 +132,7 @@ locals {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5
@@ -523,11 +523,10 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.6.7"
+  version = "0.7.2"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  resource_group_name      = azurerm_resource_group.this.name
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -539,6 +538,7 @@ module "storage_account" {
       resource_id = azurerm_user_assigned_identity.this.id
     }
   }
+  resource_group_name = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {
@@ -795,19 +795,19 @@ Version: 0.10.2
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 ### <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account)
 
 Source: Azure/avm-res-storage-storageaccount/azurerm
 
-Version: 0.6.7
+Version: 0.7.2
 
 ### <a name="module_virtual_machine"></a> [virtual\_machine](#module\_virtual\_machine)
 

--- a/examples/private-byor-cmk/README.md
+++ b/examples/private-byor-cmk/README.md
@@ -527,6 +527,7 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
+  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -538,7 +539,6 @@ module "storage_account" {
       resource_id = azurerm_user_assigned_identity.this.id
     }
   }
-  resource_group_name = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -453,6 +453,7 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
+  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -464,7 +465,6 @@ module "storage_account" {
       resource_id = azurerm_user_assigned_identity.this.id
     }
   }
-  resource_group_name = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -453,7 +453,6 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  resource_group_name      = azurerm_resource_group.this.name
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -465,6 +464,7 @@ module "storage_account" {
       resource_id = azurerm_user_assigned_identity.this.id
     }
   }
+  resource_group_name = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -449,7 +449,7 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.6.7"
+  version = "0.7.2"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -58,7 +58,7 @@ locals {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -41,7 +41,7 @@ data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -43,8 +43,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -449,11 +449,10 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.7.2"
+  version = "0.6.9"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -465,6 +464,7 @@ module "storage_account" {
       resource_id = azurerm_user_assigned_identity.this.id
     }
   }
+  resource_group_name = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -108,8 +108,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -465,11 +465,10 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.7.2"
+  version = "0.6.9"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -496,6 +495,7 @@ module "storage_account" {
       subresource_name              = "blob"
     }
   }
+  resource_group_name = azurerm_resource_group.this.name
   tags = {
     environment = "test"
   }
@@ -776,7 +776,7 @@ Version: 0.12.0
 
 Source: Azure/avm-res-storage-storageaccount/azurerm
 
-Version: 0.7.2
+Version: 0.6.9
 
 ### <a name="module_virtual_machine"></a> [virtual\_machine](#module\_virtual\_machine)
 

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -106,7 +106,7 @@ data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"
@@ -123,7 +123,7 @@ locals {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5
@@ -465,11 +465,10 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.6.7"
+  version = "0.7.2"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  resource_group_name      = azurerm_resource_group.this.name
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -496,6 +495,7 @@ module "storage_account" {
       subresource_name              = "blob"
     }
   }
+  resource_group_name = azurerm_resource_group.this.name
   tags = {
     environment = "test"
   }
@@ -764,19 +764,19 @@ Version: 0.10.2
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 ### <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account)
 
 Source: Azure/avm-res-storage-storageaccount/azurerm
 
-Version: 0.6.7
+Version: 0.7.2
 
 ### <a name="module_virtual_machine"></a> [virtual\_machine](#module\_virtual\_machine)
 

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -469,6 +469,7 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
+  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -495,7 +496,6 @@ module "storage_account" {
       subresource_name              = "blob"
     }
   }
-  resource_group_name = azurerm_resource_group.this.name
   tags = {
     environment = "test"
   }

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -404,6 +404,7 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
+  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -430,7 +431,6 @@ module "storage_account" {
       subresource_name              = "blob"
     }
   }
-  resource_group_name = azurerm_resource_group.this.name
   tags = {
     environment = "test"
   }

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -58,7 +58,7 @@ locals {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -41,7 +41,7 @@ data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -400,11 +400,10 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.7.2"
+  version = "0.6.9"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -431,6 +430,7 @@ module "storage_account" {
       subresource_name              = "blob"
     }
   }
+  resource_group_name = azurerm_resource_group.this.name
   tags = {
     environment = "test"
   }

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -400,7 +400,7 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.6.7"
+  version = "0.7.2"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -43,8 +43,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -404,7 +404,6 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  resource_group_name      = azurerm_resource_group.this.name
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
@@ -431,6 +430,7 @@ module "storage_account" {
       subresource_name              = "blob"
     }
   }
+  resource_group_name = azurerm_resource_group.this.name
   tags = {
     environment = "test"
   }

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -402,8 +402,8 @@ module "ai_foundry" {
     this = {
       endpoints = {
         blob = {
-          private_dns_zone_resource_id = azurerm_private_dns_zone.storage_blob.id
-          type                         = "blob"
+          private_dns_zone_resource_ids = [azurerm_private_dns_zone.storage_blob.id]
+          type                          = "blob"
         }
       }
     }

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -402,8 +402,8 @@ module "ai_foundry" {
     this = {
       endpoints = {
         blob = {
-          private_dns_zone_resource_ids = [azurerm_private_dns_zone.storage_blob.id]
-          type                          = "blob"
+          private_dns_zone_resource_id = azurerm_private_dns_zone.storage_blob.id
+          type                         = "blob"
         }
       }
     }

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -82,7 +82,7 @@ data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"
@@ -99,7 +99,7 @@ locals {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5
@@ -511,13 +511,13 @@ Version: 0.8.0
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 ### <a name="module_virtual_machine"></a> [virtual\_machine](#module\_virtual\_machine)
 

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -84,8 +84,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -58,7 +58,7 @@ locals {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -361,8 +361,8 @@ module "ai_foundry" {
     this = {
       endpoints = {
         blob = {
-          private_dns_zone_resource_id = azurerm_private_dns_zone.storage_blob.id
-          type                         = "blob"
+          private_dns_zone_resource_ids = [azurerm_private_dns_zone.storage_blob.id]
+          type                          = "blob"
         }
       }
     }

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -41,7 +41,7 @@ data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -43,8 +43,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -361,8 +361,8 @@ module "ai_foundry" {
     this = {
       endpoints = {
         blob = {
-          private_dns_zone_resource_ids = [azurerm_private_dns_zone.storage_blob.id]
-          type                          = "blob"
+          private_dns_zone_resource_id = azurerm_private_dns_zone.storage_blob.id
+          type                         = "blob"
         }
       }
     }

--- a/examples/public-byor/README.md
+++ b/examples/public-byor/README.md
@@ -176,15 +176,15 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.7.2"
+  version = "0.6.9"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
   account_tier             = "Standard"
+  resource_group_name      = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {
@@ -389,7 +389,7 @@ Version: 0.12.0
 
 Source: Azure/avm-res-storage-storageaccount/azurerm
 
-Version: 0.7.2
+Version: 0.6.9
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/public-byor/README.md
+++ b/examples/public-byor/README.md
@@ -180,11 +180,11 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
+  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
   account_tier             = "Standard"
-  resource_group_name      = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {

--- a/examples/public-byor/README.md
+++ b/examples/public-byor/README.md
@@ -86,8 +86,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/public-byor/README.md
+++ b/examples/public-byor/README.md
@@ -84,7 +84,7 @@ data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"
@@ -97,7 +97,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5
@@ -176,15 +176,15 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.6.7"
+  version = "0.7.2"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  resource_group_name      = azurerm_resource_group.this.name
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
   account_tier             = "Standard"
+  resource_group_name      = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {
@@ -377,19 +377,19 @@ Version: 0.10.2
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 ### <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account)
 
 Source: Azure/avm-res-storage-storageaccount/azurerm
 
-Version: 0.6.7
+Version: 0.7.2
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/public-byor/main.tf
+++ b/examples/public-byor/main.tf
@@ -130,11 +130,11 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  resource_group_name      = azurerm_resource_group.this.name
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
   account_tier             = "Standard"
+  resource_group_name      = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {

--- a/examples/public-byor/main.tf
+++ b/examples/public-byor/main.tf
@@ -126,7 +126,7 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.6.7"
+  version = "0.7.2"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique

--- a/examples/public-byor/main.tf
+++ b/examples/public-byor/main.tf
@@ -36,8 +36,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/public-byor/main.tf
+++ b/examples/public-byor/main.tf
@@ -47,7 +47,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5

--- a/examples/public-byor/main.tf
+++ b/examples/public-byor/main.tf
@@ -130,11 +130,11 @@ module "storage_account" {
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
+  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
   account_tier             = "Standard"
-  resource_group_name      = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {

--- a/examples/public-byor/main.tf
+++ b/examples/public-byor/main.tf
@@ -34,7 +34,7 @@ data "azurerm_client_config" "current" {}
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"

--- a/examples/public-byor/main.tf
+++ b/examples/public-byor/main.tf
@@ -126,15 +126,15 @@ module "key_vault" {
 
 module "storage_account" {
   source  = "Azure/avm-res-storage-storageaccount/azurerm"
-  version = "0.7.2"
+  version = "0.6.9"
 
   location                 = azurerm_resource_group.this.location
   name                     = module.naming.storage_account.name_unique
-  parent_id                = azurerm_resource_group.this.id
   access_tier              = "Hot"
   account_kind             = "StorageV2"
   account_replication_type = "ZRS"
   account_tier             = "Standard"
+  resource_group_name      = azurerm_resource_group.this.name
 }
 
 module "cosmosdb" {

--- a/examples/public-cmk/README.md
+++ b/examples/public-cmk/README.md
@@ -68,8 +68,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/public-cmk/README.md
+++ b/examples/public-cmk/README.md
@@ -66,7 +66,7 @@ locals {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"
@@ -79,7 +79,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5
@@ -258,13 +258,13 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/public-cmk/main.tf
+++ b/examples/public-cmk/main.tf
@@ -40,7 +40,7 @@ locals {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"

--- a/examples/public-cmk/main.tf
+++ b/examples/public-cmk/main.tf
@@ -53,7 +53,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5

--- a/examples/public-cmk/main.tf
+++ b/examples/public-cmk/main.tf
@@ -42,8 +42,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/public/README.md
+++ b/examples/public/README.md
@@ -68,8 +68,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/public/README.md
+++ b/examples/public/README.md
@@ -66,7 +66,7 @@ locals {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"
@@ -79,7 +79,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5
@@ -226,13 +226,13 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.5.2
+Version: 0.12.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/public/main.tf
+++ b/examples/public/main.tf
@@ -44,7 +44,7 @@ resource "random_shuffle" "locations" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 
   suffix        = [local.base_name]
   unique-length = 5

--- a/examples/public/main.tf
+++ b/examples/public/main.tf
@@ -33,8 +33,8 @@ module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  availability_zones_filter = true
-  geography_filter          = "Australia"
+  geography_filter       = "Australia"
+  has_availability_zones = true
 }
 
 resource "random_shuffle" "locations" {

--- a/examples/public/main.tf
+++ b/examples/public/main.tf
@@ -31,7 +31,7 @@ locals {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   availability_zones_filter = true
   geography_filter          = "Australia"

--- a/locals.byor.tf
+++ b/locals.byor.tf
@@ -1,4 +1,3 @@
-
 locals {
   cosmosdb_secondary_regions = { for k, v in var.cosmosdb_definition : k => (var.cosmosdb_definition[k].secondary_regions == null ? [] : (
     try(length(var.cosmosdb_definition[k].secondary_regions) == 0, false) ? [
@@ -40,4 +39,3 @@ locals {
     var.storage_account_definition[k].role_assignments
   ) }
 }
-

--- a/main.ai_search.tf
+++ b/main.ai_search.tf
@@ -67,6 +67,7 @@ resource "azurerm_private_endpoint" "pe_aisearch" {
       "searchService"
     ]
   }
+
   dynamic "private_dns_zone_group" {
     for_each = each.value.private_dns_zone_resource_id != null ? ["this"] : []
 
@@ -102,14 +103,13 @@ resource "azurerm_private_endpoint" "unmanaged_pe_aisearch" {
     ]
   }
 
+  lifecycle {
+    ignore_changes = [private_dns_zone_group]
+  }
   depends_on = [
     module.cosmosdb,
     azapi_resource.ai_search
   ]
-
-  lifecycle {
-    ignore_changes = [private_dns_zone_group]
-  }
 }
 
 resource "azurerm_role_assignment" "this_aisearch" {
@@ -159,6 +159,7 @@ resource "azurerm_monitor_diagnostic_setting" "this_aisearch" {
       category_group = enabled_log.value
     }
   }
+
   dynamic "enabled_metric" {
     for_each = each.value.metric_categories
 

--- a/main.byor.tf
+++ b/main.byor.tf
@@ -54,6 +54,7 @@ module "storage_account" {
 
   location                            = var.location
   name                                = try(each.value.name, null) != null ? each.value.name : (try(var.base_name, null) != null ? "${local.base_name_storage}${lower(each.key)}fndrysa${random_string.resource_token.result}" : "${lower(each.key)}fndrysa${random_string.resource_token.result}")
+  parent_id                           = var.resource_group_resource_id
   access_tier                         = each.value.access_tier
   account_kind                        = each.value.account_kind
   account_replication_type            = each.value.account_replication_type
@@ -77,7 +78,6 @@ module "storage_account" {
   } : {}
   private_endpoints_manage_dns_zone_group = var.private_endpoints_manage_dns_zone_groups
   public_network_access_enabled           = var.create_private_endpoints ? false : true
-  resource_group_name                     = local.resource_group_name
   role_assignments                        = local.storage_account_role_assignments[each.key] #assumes the same role assignments will be used for all storage accounts in the map.
   shared_access_key_enabled               = each.value.shared_access_key_enabled
   tags                                    = merge(var.tags, each.value.tags)

--- a/main.byor.tf
+++ b/main.byor.tf
@@ -1,7 +1,7 @@
 
 module "avm_utl_regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.5.2"
+  version = "0.12.0"
 
   enable_telemetry   = var.enable_telemetry
   recommended_filter = false

--- a/main.byor.tf
+++ b/main.byor.tf
@@ -71,7 +71,7 @@ module "storage_account" {
     for endpoint in each.value.endpoints :
     endpoint.type => {
       name                          = "${try(each.value.name, null) != null ? each.value.name : (try(var.base_name, null) != null ? "${local.base_name_storage}${lower(each.key)}fndrysa${random_string.resource_token.result}" : "${lower(each.key)}fndrysa${random_string.resource_token.result}")}-${endpoint.type}-pe"
-      private_dns_zone_resource_ids = endpoint.private_dns_zone_resource_id != null ? [endpoint.private_dns_zone_resource_id] : []
+      private_dns_zone_resource_ids = endpoint.private_dns_zone_resource_ids
       subnet_resource_id            = var.private_endpoint_subnet_resource_id
       subresource_name              = endpoint.type
     }

--- a/main.byor.tf
+++ b/main.byor.tf
@@ -55,7 +55,6 @@ module "storage_account" {
 
   location                            = var.location
   name                                = try(each.value.name, null) != null ? each.value.name : (try(var.base_name, null) != null ? "${local.base_name_storage}${lower(each.key)}fndrysa${random_string.resource_token.result}" : "${lower(each.key)}fndrysa${random_string.resource_token.result}")
-  resource_group_name                 = local.resource_group_name
   access_tier                         = each.value.access_tier
   account_kind                        = each.value.account_kind
   account_replication_type            = each.value.account_replication_type
@@ -79,6 +78,7 @@ module "storage_account" {
   } : {}
   private_endpoints_manage_dns_zone_group = var.private_endpoints_manage_dns_zone_groups
   public_network_access_enabled           = var.create_private_endpoints ? false : true
+  resource_group_name                     = local.resource_group_name
   role_assignments                        = local.storage_account_role_assignments[each.key] #assumes the same role assignments will be used for all storage accounts in the map.
   shared_access_key_enabled               = each.value.shared_access_key_enabled
   tags                                    = merge(var.tags, each.value.tags)

--- a/main.byor.tf
+++ b/main.byor.tf
@@ -1,4 +1,3 @@
-
 module "avm_utl_regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
@@ -49,12 +48,12 @@ module "key_vault" {
 
 module "storage_account" {
   source   = "Azure/avm-res-storage-storageaccount/azurerm"
-  version  = "0.7.2"
+  version  = "0.6.9"
   for_each = { for k, v in var.storage_account_definition : k => v if v.existing_resource_id == null && var.create_byor == true }
 
   location                            = var.location
   name                                = try(each.value.name, null) != null ? each.value.name : (try(var.base_name, null) != null ? "${local.base_name_storage}${lower(each.key)}fndrysa${random_string.resource_token.result}" : "${lower(each.key)}fndrysa${random_string.resource_token.result}")
-  parent_id                           = var.resource_group_resource_id
+  resource_group_name                 = local.resource_group_name
   access_tier                         = each.value.access_tier
   account_kind                        = each.value.account_kind
   account_replication_type            = each.value.account_replication_type
@@ -71,7 +70,7 @@ module "storage_account" {
     for endpoint in each.value.endpoints :
     endpoint.type => {
       name                          = "${try(each.value.name, null) != null ? each.value.name : (try(var.base_name, null) != null ? "${local.base_name_storage}${lower(each.key)}fndrysa${random_string.resource_token.result}" : "${lower(each.key)}fndrysa${random_string.resource_token.result}")}-${endpoint.type}-pe"
-      private_dns_zone_resource_ids = endpoint.private_dns_zone_resource_ids
+      private_dns_zone_resource_ids = endpoint.private_dns_zone_resource_id != null ? [endpoint.private_dns_zone_resource_id] : []
       subnet_resource_id            = var.private_endpoint_subnet_resource_id
       subresource_name              = endpoint.type
     }

--- a/main.byor.tf
+++ b/main.byor.tf
@@ -3,8 +3,7 @@ module "avm_utl_regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.12.0"
 
-  enable_telemetry   = var.enable_telemetry
-  recommended_filter = false
+  enable_telemetry = var.enable_telemetry
 }
 
 module "key_vault" {

--- a/main.byor.tf
+++ b/main.byor.tf
@@ -50,7 +50,7 @@ module "key_vault" {
 
 module "storage_account" {
   source   = "Azure/avm-res-storage-storageaccount/azurerm"
-  version  = "0.6.7"
+  version  = "0.7.2"
   for_each = { for k, v in var.storage_account_definition : k => v if v.existing_resource_id == null && var.create_byor == true }
 
   location                            = var.location

--- a/main.diagnostics.tf
+++ b/main.diagnostics.tf
@@ -24,6 +24,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category_group = enabled_log.value
     }
   }
+
   dynamic "enabled_metric" {
     for_each = each.value.metric_categories
 

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -39,7 +39,6 @@ resource "azapi_resource" "ai_foundry" {
   }
 }
 
-
 resource "azapi_resource" "ai_agent_capability_host" {
   count = var.ai_foundry.create_ai_agent_service && var.ai_foundry.network_injections == null ? 1 : 0
 
@@ -180,6 +179,7 @@ resource "azurerm_private_endpoint" "ai_foundry" {
     private_connection_resource_id = azapi_resource.ai_foundry.id
     subresource_names              = ["account"]
   }
+
   dynamic "private_dns_zone_group" {
     for_each = length(var.ai_foundry.private_dns_zone_resource_ids) > 0 ? [1] : []
 
@@ -208,11 +208,10 @@ resource "azurerm_private_endpoint" "unmanaged_ai_foundry" {
     subresource_names              = ["account"]
   }
 
-  depends_on = [azapi_resource.ai_foundry]
-
   lifecycle {
     ignore_changes = [private_dns_zone_group]
   }
+  depends_on = [azapi_resource.ai_foundry]
 }
 
 resource "azurerm_role_assignment" "foundry_role_assignments" {

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -29,6 +29,7 @@ resource "modtm_telemetry" "telemetry" {
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
 }
+
 locals {
   fork_avm = !anytrue([for r in local.valid_module_source_regex : can(regex(r, one(data.modtm_module_source.telemetry).module_source))])
 }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,6 @@ resource "random_string" "resource_token" {
   upper   = false
 }
 
-
 module "ai_foundry_project" {
   source   = "./modules/ai-foundry-project"
   for_each = var.ai_projects

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,6 @@
 #TODO: Rewrite this to return the basename of the ai search service if a resource ID is provided, otherwise return the names (or resource id)
 
+
 output "ai_agent_account_capability_host_id" {
   description = "The resource ID of the account-level AI agent capability host."
   value       = var.ai_foundry.create_ai_agent_service && var.ai_foundry.network_injections == null ? azapi_resource.ai_agent_capability_host[0].id : null

--- a/variables.byor.tf
+++ b/variables.byor.tf
@@ -260,8 +260,8 @@ variable "storage_account_definition" {
     account_tier             = optional(string, "Standard")
     account_replication_type = optional(string, "ZRS")
     endpoints = optional(map(object({
-      type                         = string
-      private_dns_zone_resource_id = optional(string, null)
+      type                          = string
+      private_dns_zone_resource_ids = optional(set(string), [])
       })), {
       blob = {
         type = "blob"
@@ -297,7 +297,7 @@ Configuration object for the Azure Storage Account to be created for GenAI servi
   - `account_replication_type` - (Optional) The replication type for the storage account. Default is "ZRS".
   - `endpoints` - (Optional) Map of endpoint configurations to enable. Default includes blob endpoint.
     - `type` - The type of endpoint (e.g., "blob", "file", "queue", "table").
-    - `private_dns_zone_resource_id` - (Optional) The resource ID of the existing private DNS zone for the endpoint. If not provided or set to null, no DNS zone group will be created.
+    - `private_dns_zone_resource_ids` - (Optional) The resource IDs of the existing private DNS zones for the endpoint. If not provided, no DNS zone group will be created.
   - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
   - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is false.
   - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.

--- a/variables.byor.tf
+++ b/variables.byor.tf
@@ -260,8 +260,8 @@ variable "storage_account_definition" {
     account_tier             = optional(string, "Standard")
     account_replication_type = optional(string, "ZRS")
     endpoints = optional(map(object({
-      type                          = string
-      private_dns_zone_resource_ids = optional(set(string), [])
+      type                         = string
+      private_dns_zone_resource_id = optional(string, null)
       })), {
       blob = {
         type = "blob"
@@ -297,7 +297,7 @@ Configuration object for the Azure Storage Account to be created for GenAI servi
   - `account_replication_type` - (Optional) The replication type for the storage account. Default is "ZRS".
   - `endpoints` - (Optional) Map of endpoint configurations to enable. Default includes blob endpoint.
     - `type` - The type of endpoint (e.g., "blob", "file", "queue", "table").
-    - `private_dns_zone_resource_ids` - (Optional) The resource IDs of the existing private DNS zones for the endpoint. If not provided, no DNS zone group will be created.
+    - `private_dns_zone_resource_id` - (Optional) The resource ID of the existing private DNS zone for the endpoint. If not provided or set to null, no DNS zone group will be created.
   - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
   - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is false.
   - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.


### PR DESCRIPTION
## Summary

Combines open Dependabot dependency bumps into a single PR.

### Dependency changes
- `Azure/naming/azurerm` → **0.4.3**
- `Azure/avm-utl-regions/azurerm` → **0.12.0**
- `Azure/avm-res-storage-storageaccount/azurerm` → **0.6.9** (root module + byor examples)

### storageaccount: 0.6.9 instead of 0.7.2

The Dependabot bump targeted storageaccount **0.7.2**, which is a major rewrite from the `azurerm` provider to **AzAPI**. The 0.7.x `private_endpoint` submodule always emits `customNetworkInterfaceName` in the AzAPI body; when null, Azure persists `""`, producing a perpetual `"" -> null` in-place diff on `azapi_resource.this` — an **idempotency failure** that surfaced only in the e2e apply and cannot be fixed from the consumer side (0.7.2 is the latest release; the submodule is not overridable).

Decision: pin to **0.6.9** (latest pre-AzAPI patch, still a safe bump from the 0.6.7 baseline on `main`). 0.6.9 uses `azurerm_private_endpoint` (no `customNetworkInterfaceName`), so idempotency is preserved. The 0.7.x migration is deferred until the upstream PE submodule bug is fixed.

### Examples
- Enabled the **private-byor** example (removed its `.e2eignore`) and verified it passes lint/format/validate/plan via `avm pr-check`. With 0.6.9's azurerm-based PEs it is idempotent.

### Validation
- `avm pre-commit` + `avm pr-check` pass for all examples (incl. private-byor).
- Final idempotency proof comes from the CI e2e (apply + plan-idempotency) on this run.