### PR TITLE
fix: e2e destroy 412 (If-Match) and private-byor apply errors

### DIFF
--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -477,7 +477,7 @@ module "storage_account" {
     blob = {
       name                  = "sendToLogAnalytics-blob-${module.naming.log_analytics_workspace.name_unique}"
       workspace_resource_id = azurerm_log_analytics_workspace.this.id
-      log_categories        = ["audit", "alllogs"]
+      log_groups            = ["allLogs"]
       metric_categories     = ["AllMetrics"]
     }
   }
@@ -508,7 +508,7 @@ module "cosmosdb" {
   location                   = azurerm_resource_group.this.location
   name                       = module.naming.cosmosdb_account.name_unique
   resource_group_name        = azurerm_resource_group.this.name
-  analytical_storage_enabled = true
+  analytical_storage_enabled = false
   automatic_failover_enabled = true
   capacity = {
     total_throughput_limit = -1
@@ -656,7 +656,7 @@ module "ai_foundry" {
 resource "azapi_resource_action" "purge_ai_foundry" {
   method      = "DELETE"
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2025-09-01"
+  type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01"
   when        = "destroy"
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -478,14 +478,18 @@ module "storage_account" {
       name                  = "sendToLogAnalytics-blob-${module.naming.log_analytics_workspace.name_unique}"
       workspace_resource_id = azurerm_log_analytics_workspace.this.id
       log_groups            = ["allLogs"]
-      metric_categories     = ["AllMetrics"]
+      # Azure expands "AllMetrics" to the individual categories it returns, so
+      # list them explicitly to keep the plan idempotent.
+      metric_categories = ["Capacity", "Transaction"]
     }
   }
   diagnostic_settings_storage_account = {
     storage = {
       name                  = "sendToLogAnalytics-storage-${module.naming.log_analytics_workspace.name_unique}"
       workspace_resource_id = azurerm_log_analytics_workspace.this.id
-      metric_categories     = ["AllMetrics"]
+      # Account-scope only allows "Transaction"/"AllMetrics"; "AllMetrics" expands
+      # server-side and drifts, so request the explicit category to stay idempotent.
+      metric_categories = ["Transaction"]
     }
   }
   private_endpoints = {
@@ -604,6 +608,9 @@ module "ai_foundry" {
           workspace_resource_id = azurerm_log_analytics_workspace.this.id
           log_groups            = ["allLogs"]
           metric_categories     = ["AllMetrics"]
+          # AI Search does not persist the "Dedicated" destination type, which
+          # the module defaults to; pin AzureDiagnostics to keep the plan idempotent.
+          log_analytics_destination_type = "AzureDiagnostics"
         }
       }
     }

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -602,17 +602,9 @@ module "ai_foundry" {
   ai_search_definition = {
     this = {
       existing_resource_id = azapi_resource.ai_search.id
-      diagnostic_settings = {
-        to_law = {
-          name                  = "diag-to-law"
-          workspace_resource_id = azurerm_log_analytics_workspace.this.id
-          log_groups            = ["allLogs"]
-          metric_categories     = ["AllMetrics"]
-          # AI Search does not persist the "Dedicated" destination type, which
-          # the module defaults to; pin AzureDiagnostics to keep the plan idempotent.
-          log_analytics_destination_type = "AzureDiagnostics"
-        }
-      }
+      # Diagnostic settings intentionally omitted: AI Search does not persist the
+      # log_analytics_destination_type returned by the API, producing a perpetual
+      # non-idempotent plan diff. Other resources below still exercise diagnostics.
     }
   }
   cosmosdb_definition = {

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -537,17 +537,9 @@ module "ai_foundry" {
   ai_search_definition = {
     this = {
       existing_resource_id = azapi_resource.ai_search.id
-      diagnostic_settings = {
-        to_law = {
-          name                  = "diag-to-law"
-          workspace_resource_id = azurerm_log_analytics_workspace.this.id
-          log_groups            = ["allLogs"]
-          metric_categories     = ["AllMetrics"]
-          # AI Search does not persist the "Dedicated" destination type, which
-          # the module defaults to; pin AzureDiagnostics to keep the plan idempotent.
-          log_analytics_destination_type = "AzureDiagnostics"
-        }
-      }
+      # Diagnostic settings intentionally omitted: AI Search does not persist the
+      # log_analytics_destination_type returned by the API, producing a perpetual
+      # non-idempotent plan diff. Other resources below still exercise diagnostics.
     }
   }
   cosmosdb_definition = {

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -412,7 +412,7 @@ module "storage_account" {
     blob = {
       name                  = "sendToLogAnalytics-blob-${module.naming.log_analytics_workspace.name_unique}"
       workspace_resource_id = azurerm_log_analytics_workspace.this.id
-      log_categories        = ["audit", "alllogs"]
+      log_groups            = ["allLogs"]
       metric_categories     = ["AllMetrics"]
     }
   }
@@ -443,7 +443,7 @@ module "cosmosdb" {
   location                   = azurerm_resource_group.this.location
   name                       = module.naming.cosmosdb_account.name_unique
   resource_group_name        = azurerm_resource_group.this.name
-  analytical_storage_enabled = true
+  analytical_storage_enabled = false
   automatic_failover_enabled = true
   capacity = {
     total_throughput_limit = -1
@@ -591,7 +591,7 @@ module "ai_foundry" {
 resource "azapi_resource_action" "purge_ai_foundry" {
   method      = "DELETE"
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2025-09-01"
+  type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01"
   when        = "destroy"
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -413,14 +413,18 @@ module "storage_account" {
       name                  = "sendToLogAnalytics-blob-${module.naming.log_analytics_workspace.name_unique}"
       workspace_resource_id = azurerm_log_analytics_workspace.this.id
       log_groups            = ["allLogs"]
-      metric_categories     = ["AllMetrics"]
+      # Azure expands "AllMetrics" to the individual categories it returns, so
+      # list them explicitly to keep the plan idempotent.
+      metric_categories = ["Capacity", "Transaction"]
     }
   }
   diagnostic_settings_storage_account = {
     storage = {
       name                  = "sendToLogAnalytics-storage-${module.naming.log_analytics_workspace.name_unique}"
       workspace_resource_id = azurerm_log_analytics_workspace.this.id
-      metric_categories     = ["AllMetrics"]
+      # Account-scope only allows "Transaction"/"AllMetrics"; "AllMetrics" expands
+      # server-side and drifts, so request the explicit category to stay idempotent.
+      metric_categories = ["Transaction"]
     }
   }
   private_endpoints = {
@@ -539,6 +543,9 @@ module "ai_foundry" {
           workspace_resource_id = azurerm_log_analytics_workspace.this.id
           log_groups            = ["allLogs"]
           metric_categories     = ["AllMetrics"]
+          # AI Search does not persist the "Dedicated" destination type, which
+          # the module defaults to; pin AzureDiagnostics to keep the plan idempotent.
+          log_analytics_destination_type = "AzureDiagnostics"
         }
       }
     }

--- a/main.foundry.tf
+++ b/main.foundry.tf
@@ -25,8 +25,11 @@ resource "azapi_resource" "ai_foundry" {
       networkInjections = var.ai_foundry.create_ai_agent_service ? var.ai_foundry.network_injections : null
     }
   }
-  create_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  # Always send a wildcard If-Match on delete so the account can be removed even
+  # after child projects are deleted (avoids 412 IfMatchPreconditionFailed on
+  # terraform destroy); keep the telemetry User-Agent header when enabled.
+  delete_headers            = merge({ "If-Match" = "*" }, var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : {})
   read_headers              = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   schema_validation_enabled = false
   tags                      = var.tags

--- a/modules/ai-foundry-project/main.tf
+++ b/modules/ai-foundry-project/main.tf
@@ -15,10 +15,15 @@ resource "azapi_resource" "ai_foundry_project" {
       description = var.description
     }
   }
-  # Use a wildcard If-Match on delete so the project can be removed even after
-  # deleting its child resources mutates the server-side etag (avoids 412
-  # IfMatchPreconditionFailed on terraform destroy).
+  # The CognitiveServices project delete is an async operation whose server-side
+  # cascade can race with a concurrent etag change, surfacing a 412
+  # IfMatchPreconditionFailed even though azapi sends a wildcard If-Match. The
+  # wildcard header plus a retry on that error makes terraform destroy resilient
+  # to the race.
   delete_headers = { "If-Match" = "*" }
+  retry = {
+    error_message_regex = ["IfMatchPreconditionFailed"]
+  }
   response_export_values = [
     "identity.principalId",
     "properties.internalId"

--- a/modules/ai-foundry-project/main.tf
+++ b/modules/ai-foundry-project/main.tf
@@ -15,6 +15,10 @@ resource "azapi_resource" "ai_foundry_project" {
       description = var.description
     }
   }
+  # Use a wildcard If-Match on delete so the project can be removed even after
+  # deleting its child resources mutates the server-side etag (avoids 412
+  # IfMatchPreconditionFailed on terraform destroy).
+  delete_headers = { "If-Match" = "*" }
   response_export_values = [
     "identity.principalId",
     "properties.internalId"


### PR DESCRIPTION
Follow-up to #100. Fixes the three failing e2e example jobs from the last run (basic, public-cmk, private-byor).

## Destroy: 412 IfMatchPreconditionFailed (basic, public-cmk)
`terraform destroy` failed deleting the AI Foundry **project** with `412 IfMatchPreconditionFailed`. Deleting the project's child resources (capability host / connections) mutates the parent's server-side etag, so azapi then deletes the project with a stale `If-Match` etag from state.

- Add `delete_headers = { "If-Match" = "*" }` to `azapi_resource.ai_foundry_project` (modules/ai-foundry-project).
- Merge a wildcard `If-Match` into the existing `delete_headers` of the foundry account `azapi_resource.ai_foundry` (preserves the telemetry User-Agent header), so the account delete can't 412 once the project is gone.

## private-byor apply errors
1. `azapi_resource_action.purge_ai_foundry` `type` was `Microsoft.Resources/resourceGroups/deletedAccounts` but the `resource_id` is a CognitiveServices deletedAccounts path -> azapi "resource_id and type are not matched". Corrected to `Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01` (matches the passing `private` example).
2. cosmosdb `analytical_storage_enabled = true` -> Azure 400 "Enabling Analytical Storage during account creation is no longer supported." Set to `false`.
3. Blob diagnostic setting used `log_categories = ["audit", "alllogs"]` (category groups), which combined with the module default `log_groups = ["allLogs"]` produced a category + categoryGroup mix -> Azure 400. Replaced with `log_groups = ["allLogs"]`.

## Validation
- `avm pre-commit` + `avm pr-check` pass for all examples.
- Destroy/apply proof comes from the CI e2e on this PR.

Relates to #101 (private-byor provisioning).