### PR TITLE
chore(deps): bump bastionhost 0.8.0→0.9.0 and compute-vm 0.19.3→0.21.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,14 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # avm-res-storage-storageaccount has an idempotency bug introduced in
+      # 0.7.2 that this module cannot work around. Stay on 0.6.9 and only
+      # surface major version updates until the regression is resolved.
+      - dependency-name: "Azure/avm-res-storage-storageaccount/azurerm"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   # GitHub Actions workflows and composite actions under .github/.
   - package-ecosystem: github-actions

--- a/examples/private-byor-cmk/README.md
+++ b/examples/private-byor-cmk/README.md
@@ -360,7 +360,7 @@ resource "azurerm_public_ip" "example" {
 
 module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
-  version = "0.8.0"
+  version = "0.9.0"
 
   location            = azurerm_resource_group.this.location
   name                = module.naming.bastion_host.name_unique
@@ -378,7 +378,7 @@ module "bastion_host" {
 
 module "virtual_machine" {
   source  = "Azure/avm-res-compute-virtualmachine/azurerm"
-  version = "0.19.3"
+  version = "0.21.0"
 
   location = azurerm_resource_group.this.location
   name     = module.naming.virtual_machine.name_unique
@@ -777,7 +777,7 @@ Version:
 
 Source: Azure/avm-res-network-bastionhost/azurerm
 
-Version: 0.8.0
+Version: 0.9.0
 
 ### <a name="module_cosmosdb"></a> [cosmosdb](#module\_cosmosdb)
 
@@ -813,7 +813,7 @@ Version: 0.6.9
 
 Source: Azure/avm-res-compute-virtualmachine/azurerm
 
-Version: 0.19.3
+Version: 0.21.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/private-byor-cmk/README.md
+++ b/examples/private-byor-cmk/README.md
@@ -362,9 +362,9 @@ module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
   version = "0.9.0"
 
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.bastion_host.name_unique
+  parent_id = azurerm_resource_group.this.id
   ip_configuration = {
     name                 = "default-ipconfig"
     subnet_id            = azurerm_subnet.bastion.id

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -286,7 +286,7 @@ resource "azurerm_public_ip" "example" {
 
 module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
-  version = "0.8.0"
+  version = "0.9.0"
 
   location            = azurerm_resource_group.this.location
   name                = module.naming.bastion_host.name_unique
@@ -304,7 +304,7 @@ module "bastion_host" {
 
 module "virtual_machine" {
   source  = "Azure/avm-res-compute-virtualmachine/azurerm"
-  version = "0.19.3"
+  version = "0.21.0"
 
   location = azurerm_resource_group.this.location
   name     = module.naming.virtual_machine.name_unique

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -288,9 +288,9 @@ module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
   version = "0.9.0"
 
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.bastion_host.name_unique
+  parent_id = azurerm_resource_group.this.id
   ip_configuration = {
     name                 = "default-ipconfig"
     subnet_id            = azurerm_subnet.bastion.id

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -302,9 +302,9 @@ module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
   version = "0.9.0"
 
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.bastion_host.name_unique
+  parent_id = azurerm_resource_group.this.id
   ip_configuration = {
     name                 = "default-ipconfig"
     subnet_id            = azurerm_subnet.bastion.id

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -300,7 +300,7 @@ resource "azurerm_public_ip" "example" {
 
 module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
-  version = "0.8.0"
+  version = "0.9.0"
 
   location            = azurerm_resource_group.this.location
   name                = module.naming.bastion_host.name_unique
@@ -318,7 +318,7 @@ module "bastion_host" {
 
 module "virtual_machine" {
   source  = "Azure/avm-res-compute-virtualmachine/azurerm"
-  version = "0.19.3"
+  version = "0.21.0"
 
   location = azurerm_resource_group.this.location
   name     = module.naming.virtual_machine.name_unique
@@ -745,7 +745,7 @@ Version:
 
 Source: Azure/avm-res-network-bastionhost/azurerm
 
-Version: 0.8.0
+Version: 0.9.0
 
 ### <a name="module_cosmosdb"></a> [cosmosdb](#module\_cosmosdb)
 
@@ -781,7 +781,7 @@ Version: 0.6.9
 
 Source: Azure/avm-res-compute-virtualmachine/azurerm
 
-Version: 0.19.3
+Version: 0.21.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -237,9 +237,9 @@ module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
   version = "0.9.0"
 
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.bastion_host.name_unique
+  parent_id = azurerm_resource_group.this.id
   ip_configuration = {
     name                 = "default-ipconfig"
     subnet_id            = azurerm_subnet.bastion.id

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -235,7 +235,7 @@ resource "azurerm_public_ip" "example" {
 
 module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
-  version = "0.8.0"
+  version = "0.9.0"
 
   location            = azurerm_resource_group.this.location
   name                = module.naming.bastion_host.name_unique
@@ -253,7 +253,7 @@ module "bastion_host" {
 
 module "virtual_machine" {
   source  = "Azure/avm-res-compute-virtualmachine/azurerm"
-  version = "0.19.3"
+  version = "0.21.0"
 
   location = azurerm_resource_group.this.location
   name     = module.naming.virtual_machine.name_unique

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -278,9 +278,9 @@ module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
   version = "0.9.0"
 
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.bastion_host.name_unique
+  parent_id = azurerm_resource_group.this.id
   ip_configuration = {
     name                 = "default-ipconfig"
     subnet_id            = azurerm_subnet.bastion.id

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -276,7 +276,7 @@ resource "azurerm_public_ip" "example" {
 
 module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
-  version = "0.8.0"
+  version = "0.9.0"
 
   location            = azurerm_resource_group.this.location
   name                = module.naming.bastion_host.name_unique
@@ -294,7 +294,7 @@ module "bastion_host" {
 
 module "virtual_machine" {
   source  = "Azure/avm-res-compute-virtualmachine/azurerm"
-  version = "0.19.3"
+  version = "0.21.0"
 
   location = azurerm_resource_group.this.location
   name     = module.naming.virtual_machine.name_unique
@@ -505,7 +505,7 @@ Version:
 
 Source: Azure/avm-res-network-bastionhost/azurerm
 
-Version: 0.8.0
+Version: 0.9.0
 
 ### <a name="module_naming"></a> [naming](#module\_naming)
 
@@ -523,7 +523,7 @@ Version: 0.12.0
 
 Source: Azure/avm-res-compute-virtualmachine/azurerm
 
-Version: 0.19.3
+Version: 0.21.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -237,9 +237,9 @@ module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
   version = "0.9.0"
 
-  location            = azurerm_resource_group.this.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this.name
+  location  = azurerm_resource_group.this.location
+  name      = module.naming.bastion_host.name_unique
+  parent_id = azurerm_resource_group.this.id
   ip_configuration = {
     name                 = "default-ipconfig"
     subnet_id            = azurerm_subnet.bastion.id

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -235,7 +235,7 @@ resource "azurerm_public_ip" "example" {
 
 module "bastion_host" {
   source  = "Azure/avm-res-network-bastionhost/azurerm"
-  version = "0.8.0"
+  version = "0.9.0"
 
   location            = azurerm_resource_group.this.location
   name                = module.naming.bastion_host.name_unique
@@ -253,7 +253,7 @@ module "bastion_host" {
 
 module "virtual_machine" {
   source  = "Azure/avm-res-compute-virtualmachine/azurerm"
-  version = "0.19.3"
+  version = "0.21.0"
 
   location = azurerm_resource_group.this.location
   name     = module.naming.virtual_machine.name_unique


### PR DESCRIPTION
Bundles the outstanding non-storage dependabot version bumps into a single PR.

## Changes
| Module | From | To | Examples |
|--------|------|----|----------|
| `avm-res-network-bastionhost/azurerm` | 0.8.0 | 0.9.0 | private, private-byor, private-byor-cmk |
| `avm-res-compute-virtualmachine/azurerm` | 0.19.3 | 0.21.0 | private, private-byor, private-byor-cmk |

Supersedes dependabot PRs #103, #104, #105, #106, #107, #108 (close those in favor of this one).

## Storage account note
Also adds a `dependabot.yml` ignore rule for `avm-res-storage-storageaccount/azurerm` minor/patch updates. Versions ≥ 0.7.2 introduce a storage account idempotency bug this module cannot work around, so we stay on 0.6.9 until a major release resolves it (dependabot PRs #88, #91, #96 declined).