### PR TITLE
Fix output condition to match the `ai_agent_capability_host` resource's count expression

### DIFF
--- a/modules/ai-foundry-project/outputs.tf
+++ b/modules/ai-foundry-project/outputs.tf
@@ -1,6 +1,6 @@
 output "ai_agent_capability_host_id" {
   description = "Resource ID of the AI agent capability host"
-  value       = var.create_ai_agent_service ? azapi_resource.ai_agent_capability_host[0].id : null
+  value       = var.create_ai_agent_service && var.create_project_connections ? azapi_resource.ai_agent_capability_host[0].id : null
 }
 
 output "ai_foundry_project_id" {


### PR DESCRIPTION
## Description
Closes #127 
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
