### PR TITLE
feat: expose network ACL and IP allowlist inputs for BYOR resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ Description: Configuration object for the Azure AI Search service to be created 
   - `replica_count` - (Optional) The number of replicas for the search service. Default is 2.
   - `semantic_search` - (Optional) The semantic search tier. Possible values are "disabled", "free", or "standard". Default is "disabled".
   - `hosting_mode` - (Optional) The hosting mode for the search service. Default is "default".
+  - `public_network_access_enabled` - (Optional) Overrides public network access on the search service. Default is null, in which case the value is derived from `create_private_endpoints` (disabled when private endpoints are created, enabled otherwise).
+  - `network_rule_set` - (Optional) Inbound network rules applied to the search service. Only takes effect when public network access is enabled.
+    - `bypass` - (Optional) Whether trusted Azure services may bypass the rules. Possible values are "None" and "AzureServices". Default is "None".
+    - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed inbound access. Default is [].
   - `tags` - (Optional) Map of tags to assign to the AI Search service.
   - `role_assignments` - (Optional) Map of role assignments to create on the AI Search service. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
     - `role_definition_id_or_name` - The role definition ID or name to assign.
@@ -355,13 +359,18 @@ map(object({
       event_hub_name                           = optional(string, null)
       marketplace_partner_resource_id          = optional(string, null)
     })), {})
-    sku                          = optional(string, "standard")
-    local_authentication_enabled = optional(bool, true)
-    partition_count              = optional(number, 1)
-    replica_count                = optional(number, 2)
-    semantic_search              = optional(string, "disabled")
-    hosting_mode                 = optional(string, "default")
-    tags                         = optional(map(string), {})
+    sku                           = optional(string, "standard")
+    local_authentication_enabled  = optional(bool, true)
+    partition_count               = optional(number, 1)
+    replica_count                 = optional(number, 2)
+    semantic_search               = optional(string, "disabled")
+    hosting_mode                  = optional(string, "default")
+    public_network_access_enabled = optional(bool, null)
+    network_rule_set = optional(object({
+      bypass   = optional(string, "None")
+      ip_rules = optional(list(string), [])
+    }), {})
+    tags = optional(map(string), {})
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
@@ -405,6 +414,11 @@ Description: Configuration object for the Azure Cosmos DB account to be created 
   - `local_authentication_disabled` - (Optional) Whether local authentication is disabled. Default is true.
   - `partition_merge_enabled` - (Optional) Whether partition merge is enabled. Default is false.
   - `multiple_write_locations_enabled` - (Optional) Whether multiple write locations are enabled. Default is false.
+  - `ip_range_filter` - (Optional) Set of IP addresses or CIDR ranges allowed to reach the Cosmos DB account. Defaults to the Azure portal and global Azure datacenter source IPs documented at https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall. Set to `[]` to remove the allowlist.
+  - `network_acl_bypass_for_azure_services` - (Optional) Whether Azure services can bypass the network ACLs. Default is true.
+  - `network_acl_bypass_resource_ids` - (Optional) Set of resource IDs allowed to bypass the network ACLs. Default is [].
+  - `virtual_network_rules` - (Optional) Set of subnets allowed to reach the Cosmos DB account. Default is [].
+    - `subnet_id` - The resource ID of the subnet to allow.
   - `analytical_storage_config` - (Optional) Analytical storage configuration.
     - `schema_type` - The schema type for analytical storage.
   - `consistency_policy` - (Optional) Consistency policy configuration.
@@ -468,6 +482,18 @@ map(object({
     local_authentication_disabled    = optional(bool, true)
     partition_merge_enabled          = optional(bool, false)
     multiple_write_locations_enabled = optional(bool, false)
+    # Default allowlist is the Azure portal plus global Azure datacenter source IPs: https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall
+    ip_range_filter = optional(set(string), [
+      "168.125.123.255",
+      "170.0.0.0/24",
+      "0.0.0.0",
+      "104.42.195.92", "40.76.54.131", "52.176.6.30", "52.169.50.45", "52.187.184.26"
+    ])
+    network_acl_bypass_for_azure_services = optional(bool, true)
+    network_acl_bypass_resource_ids       = optional(set(string), [])
+    virtual_network_rules = optional(set(object({
+      subnet_id = string
+    })), [])
     analytical_storage_config = optional(object({
       schema_type = string
     }), null)
@@ -583,6 +609,12 @@ Description: Configuration object for the Azure Key Vault to be created for GenA
   - `diagnostic_settings` - (Optional) A map of diagnostic settings to create. Each entry follows the AVM diagnostic\_settings interface.
   - `sku` - (Optional) The SKU of the Key Vault. Default is "standard".
   - `tenant_id` - (Optional) The tenant ID for the Key Vault. If not provided, the current tenant will be used.
+  - `public_network_access_enabled` - (Optional) Overrides public network access on the Key Vault. Default is null, in which case the value is derived from `create_private_endpoints` (disabled when private endpoints are created, enabled otherwise).
+  - `network_acls` - (Optional) Network access control list applied to the Key Vault. Defaults to allowing all networks with an `AzureServices` bypass, which preserves the module's previous behaviour.
+    - `bypass` - (Optional) Traffic permitted to bypass the rules. Possible values are "AzureServices" and "None". Default is "AzureServices".
+    - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Allow".
+    - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed access. Default is [].
+    - `virtual_network_subnet_ids` - (Optional) List of subnet resource IDs allowed access. Default is [].
   - `role_assignments` - (Optional) Map of role assignments to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
     - `role_definition_id_or_name` - The role definition ID or name to assign.
     - `principal_id` - The principal ID to assign the role to.
@@ -613,8 +645,15 @@ map(object({
       event_hub_name                           = optional(string, null)
       marketplace_partner_resource_id          = optional(string, null)
     })), {})
-    sku       = optional(string, "standard")
-    tenant_id = optional(string)
+    sku                           = optional(string, "standard")
+    tenant_id                     = optional(string)
+    public_network_access_enabled = optional(bool, null)
+    network_acls = optional(object({
+      bypass                     = optional(string, "AzureServices")
+      default_action             = optional(string, "Allow")
+      ip_rules                   = optional(list(string), [])
+      virtual_network_subnet_ids = optional(list(string), [])
+    }), {})
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
@@ -696,6 +735,15 @@ Description: Configuration object for the Azure Storage Account to be created fo
     - `private_dns_zone_resource_id` - (Optional) The resource ID of the existing private DNS zone for the endpoint. If not provided or set to null, no DNS zone group will be created.
   - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
   - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is false.
+  - `public_network_access_enabled` - (Optional) Overrides public network access on the Storage Account. Default is null, in which case the value is derived from `create_private_endpoints` (disabled when private endpoints are created, enabled otherwise).
+  - `network_rules` - (Optional) Storage account firewall configuration. Default is null, in which case the module keeps its previous behaviour: deny-by-default with an `AzureServices` bypass when `create_private_endpoints` is true, and no network rules at all when it is false.
+    - `bypass` - (Optional) Traffic permitted to bypass the rules. Any combination of "Logging", "Metrics", "AzureServices" or "None". Default is ["AzureServices"].
+    - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Deny".
+    - `ip_rules` - (Optional) Set of public IPv4 addresses or CIDR ranges allowed access. RFC 1918 private ranges are not permitted by Azure. Default is [].
+    - `virtual_network_subnet_ids` - (Optional) Set of subnet resource IDs allowed access. Default is [].
+    - `private_link_access` - (Optional) List of resource access rules granting private link access. Default is null.
+      - `endpoint_resource_id` - The resource ID granted access.
+      - `endpoint_tenant_id` - (Optional) The tenant ID of the resource. Defaults to the current tenant.
   - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
     - `role_definition_id_or_name` - The role definition ID or name to assign.
     - `principal_id` - The principal ID to assign the role to.
@@ -736,8 +784,19 @@ map(object({
         type = "blob"
       }
     })
-    access_tier               = optional(string, "Hot")
-    shared_access_key_enabled = optional(bool, false)
+    access_tier                   = optional(string, "Hot")
+    shared_access_key_enabled     = optional(bool, false)
+    public_network_access_enabled = optional(bool, null)
+    network_rules = optional(object({
+      bypass                     = optional(set(string), ["AzureServices"])
+      default_action             = optional(string, "Deny")
+      ip_rules                   = optional(set(string), [])
+      virtual_network_subnet_ids = optional(set(string), [])
+      private_link_access = optional(list(object({
+        endpoint_resource_id = string
+        endpoint_tenant_id   = optional(string)
+      })), null)
+    }), null)
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string

--- a/examples/private-byor-cmk/README.md
+++ b/examples/private-byor-cmk/README.md
@@ -693,6 +693,14 @@ resource "azapi_resource_action" "purge_ai_foundry" {
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
   type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
   when        = "destroy"
+  # Deleting the account is asynchronous, so the purge can be issued while the
+  # account provisioning state is still non terminal, which returns a 409
+  # RequestConflict. Retry until the deletion settles.
+  retry = {
+    error_message_regex  = ["RequestConflict"]
+    interval_seconds     = 30
+    max_interval_seconds = 120
+  }
 }
 ```
 

--- a/examples/private-byor-cmk/main.tf
+++ b/examples/private-byor-cmk/main.tf
@@ -619,4 +619,12 @@ resource "azapi_resource_action" "purge_ai_foundry" {
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
   type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
   when        = "destroy"
+  # Deleting the account is asynchronous, so the purge can be issued while the
+  # account provisioning state is still non terminal, which returns a 409
+  # RequestConflict. Retry until the deletion settles.
+  retry = {
+    error_message_regex  = ["RequestConflict"]
+    interval_seconds     = 30
+    max_interval_seconds = 120
+  }
 }

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -670,7 +670,7 @@ resource "azapi_resource_action" "purge_ai_foundry" {
 }
 
 resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "900s" # 10m
+  destroy_duration = "20m"
 
   depends_on = [azurerm_subnet.agent_services]
 }

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -670,6 +670,7 @@ resource "azapi_resource_action" "purge_ai_foundry" {
 }
 
 resource "time_sleep" "purge_ai_foundry_cooldown" {
+  # Allow the AI Agents service association link to clear before subnet deletion.
   destroy_duration = "20m"
 
   depends_on = [azurerm_subnet.agent_services]

--- a/examples/private-byor/README.md
+++ b/examples/private-byor/README.md
@@ -657,6 +657,14 @@ resource "azapi_resource_action" "purge_ai_foundry" {
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
   type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01"
   when        = "destroy"
+  # Deleting the account is asynchronous, so the purge can be issued while the
+  # account provisioning state is still non terminal, which returns a 409
+  # RequestConflict. Retry until the deletion settles.
+  retry = {
+    error_message_regex  = ["RequestConflict"]
+    interval_seconds     = 30
+    max_interval_seconds = 120
+  }
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -605,6 +605,7 @@ resource "azapi_resource_action" "purge_ai_foundry" {
 }
 
 resource "time_sleep" "purge_ai_foundry_cooldown" {
+  # Allow the AI Agents service association link to clear before subnet deletion.
   destroy_duration = "20m"
 
   depends_on = [azurerm_subnet.agent_services]

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -583,7 +583,7 @@ module "ai_foundry" {
     }
   }
 
-  depends_on = [time_sleep.purge_ai_foundry_cooldown]
+  depends_on = [azapi_resource_action.purge_ai_foundry]
 }
 
 # Purge deleted AI Foundry account to release service association links
@@ -600,13 +600,12 @@ resource "azapi_resource_action" "purge_ai_foundry" {
     interval_seconds     = 30
     max_interval_seconds = 120
   }
+
+  depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }
 
 resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "900s" # 15m
+  destroy_duration = "20m"
 
-  depends_on = [
-    azurerm_subnet.agent_services,
-    azapi_resource_action.purge_ai_foundry
-  ]
+  depends_on = [azurerm_subnet.agent_services]
 }

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -592,6 +592,14 @@ resource "azapi_resource_action" "purge_ai_foundry" {
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
   type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01"
   when        = "destroy"
+  # Deleting the account is asynchronous, so the purge can be issued while the
+  # account provisioning state is still non terminal, which returns a 409
+  # RequestConflict. Retry until the deletion settles.
+  retry = {
+    error_message_regex  = ["RequestConflict"]
+    interval_seconds     = 30
+    max_interval_seconds = 120
+  }
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -474,14 +474,30 @@ module "cosmosdb" {
   multiple_write_locations_enabled      = false
   network_acl_bypass_for_azure_services = true
   partition_merge_enabled               = false
-  private_endpoints = {
-    "cosmosdb" = {
-      private_dns_zone_resource_ids = [azurerm_private_dns_zone.cosmosdb.id]
-      subnet_resource_id            = azurerm_subnet.private_endpoints.id
-      subresource_name              = "sql"
-    }
-  }
   public_network_access_enabled = true
+}
+
+resource "azurerm_private_endpoint" "cosmosdb" {
+  location            = azurerm_resource_group.this.location
+  name                = "pep-${module.naming.cosmosdb_account.name_unique}"
+  resource_group_name = azurerm_resource_group.this.name
+  subnet_id           = azurerm_subnet.private_endpoints.id
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = "pse-cosmosdb"
+    private_connection_resource_id = module.cosmosdb.resource_id
+    subresource_names              = ["sql"]
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.cosmosdb.id]
+  }
+
+  timeouts {
+    delete = "90m"
+  }
 }
 
 module "ai_foundry" {

--- a/examples/private-byor/main.tf
+++ b/examples/private-byor/main.tf
@@ -583,7 +583,7 @@ module "ai_foundry" {
     }
   }
 
-  depends_on = [azapi_resource_action.purge_ai_foundry]
+  depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }
 
 # Purge deleted AI Foundry account to release service association links
@@ -600,12 +600,13 @@ resource "azapi_resource_action" "purge_ai_foundry" {
     interval_seconds     = 30
     max_interval_seconds = 120
   }
-
-  depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }
 
 resource "time_sleep" "purge_ai_foundry_cooldown" {
-  destroy_duration = "900s" # 10m
+  destroy_duration = "900s" # 15m
 
-  depends_on = [azurerm_subnet.agent_services]
+  depends_on = [
+    azurerm_subnet.agent_services,
+    azapi_resource_action.purge_ai_foundry
+  ]
 }

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -418,6 +418,14 @@ resource "azapi_resource_action" "purge_ai_foundry" {
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
   type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01"
   when        = "destroy"
+  # Deleting the account is asynchronous, so the purge can be issued while the
+  # account provisioning state is still non terminal, which returns a 409
+  # RequestConflict. Retry until the deletion settles.
+  retry = {
+    error_message_regex  = ["RequestConflict"]
+    interval_seconds     = 30
+    max_interval_seconds = 120
+  }
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -377,6 +377,14 @@ resource "azapi_resource_action" "purge_ai_foundry" {
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/${module.naming.cognitive_account.name_unique}"
   type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01"
   when        = "destroy"
+  # Deleting the account is asynchronous, so the purge can be issued while the
+  # account provisioning state is still non terminal, which returns a 409
+  # RequestConflict. Retry until the deletion settles.
+  retry = {
+    error_message_regex  = ["RequestConflict"]
+    interval_seconds     = 30
+    max_interval_seconds = 120
+  }
 
   depends_on = [time_sleep.purge_ai_foundry_cooldown]
 }

--- a/locals.ai_search.tf
+++ b/locals.ai_search.tf
@@ -1,4 +1,7 @@
 locals {
+  ai_search_public_network_access = { for k, v in var.ai_search_definition : k => (
+    v.public_network_access_enabled != null ? (v.public_network_access_enabled ? "Enabled" : "Disabled") : (var.create_private_endpoints ? "Disabled" : "Enabled")
+  ) }
   ai_search_rbac = { for role in flatten([
     for ak, av in var.ai_search_definition : [
       for rk, rv in av.role_assignments : {

--- a/locals.byor.tf
+++ b/locals.byor.tf
@@ -34,6 +34,16 @@ locals {
   #################################################################
   # Storage Account specific local variables
   #################################################################
+  # Falls back to the module's previous behaviour when a definition omits network_rules.
+  storage_account_network_rules = { for k, v in var.storage_account_definition : k => (
+    v.network_rules != null ? v.network_rules : (var.create_private_endpoints ? {
+      bypass                     = ["AzureServices"]
+      default_action             = "Deny"
+      ip_rules                   = []
+      virtual_network_subnet_ids = []
+      private_link_access        = null
+    } : null)
+  ) }
   storage_account_role_assignments = { for k, v in var.storage_account_definition : k => merge(
     local.storage_account_default_role_assignments,
     var.storage_account_definition[k].role_assignments

--- a/main.ai_search.tf
+++ b/main.ai_search.tf
@@ -27,10 +27,15 @@ resource "azapi_resource" "ai_search" {
         disableLocalAuth = each.value.local_authentication_enabled ? false : true #inverted logic to match the variable definition
 
         # Networking-related controls
-        publicNetworkAccess = var.create_private_endpoints ? "Disabled" : "Enabled"
-        networkRuleSet = {
-          bypass = "None"
-        }
+        publicNetworkAccess = local.ai_search_public_network_access[each.key]
+        networkRuleSet = merge(
+          {
+            bypass = each.value.network_rule_set.bypass
+          },
+          length(each.value.network_rule_set.ip_rules) > 0 ? {
+            ipRules = [for ip in each.value.network_rule_set.ip_rules : { value = ip }]
+          } : {}
+        )
       },
       each.value.local_authentication_enabled ? {
         authOptions = {

--- a/main.byor.tf
+++ b/main.byor.tf
@@ -19,10 +19,7 @@ module "key_vault" {
   enabled_for_deployment          = true
   enabled_for_disk_encryption     = true
   enabled_for_template_deployment = true
-  network_acls = { #TODO check to see if we need to support custom network ACLs and if this should be deny by default.
-    default_action = "Allow"
-    bypass         = "AzureServices"
-  }
+  network_acls                    = each.value.network_acls
   private_endpoints = var.create_private_endpoints ? {
     "vault" = {
       private_dns_zone_resource_ids = each.value.private_dns_zone_resource_id != null ? [each.value.private_dns_zone_resource_id] : []
@@ -31,7 +28,7 @@ module "key_vault" {
     }
   } : {}
   private_endpoints_manage_dns_zone_group = var.private_endpoints_manage_dns_zone_groups
-  public_network_access_enabled           = var.create_private_endpoints ? false : true
+  public_network_access_enabled           = each.value.public_network_access_enabled != null ? each.value.public_network_access_enabled : (var.create_private_endpoints ? false : true)
   role_assignments                        = local.key_vault_role_assignments[each.key]
   tags                                    = each.value.tags
   wait_for_rbac_before_key_operations = {
@@ -60,12 +57,7 @@ module "storage_account" {
   account_tier                        = each.value.account_tier
   diagnostic_settings_storage_account = each.value.diagnostic_settings_storage_account
   enable_telemetry                    = var.enable_telemetry
-  network_rules = var.create_private_endpoints ? {
-    default_action             = "Deny"
-    bypass                     = ["AzureServices"]
-    ip_rules                   = []
-    virtual_network_subnet_ids = []
-  } : null
+  network_rules                       = local.storage_account_network_rules[each.key]
   private_endpoints = var.create_private_endpoints ? {
     for endpoint in each.value.endpoints :
     endpoint.type => {
@@ -76,7 +68,7 @@ module "storage_account" {
     }
   } : {}
   private_endpoints_manage_dns_zone_group = var.private_endpoints_manage_dns_zone_groups
-  public_network_access_enabled           = var.create_private_endpoints ? false : true
+  public_network_access_enabled           = each.value.public_network_access_enabled != null ? each.value.public_network_access_enabled : (var.create_private_endpoints ? false : true)
   role_assignments                        = local.storage_account_role_assignments[each.key] #assumes the same role assignments will be used for all storage accounts in the map.
   shared_access_key_enabled               = each.value.shared_access_key_enabled
   tags                                    = merge(var.tags, each.value.tags)
@@ -101,19 +93,15 @@ module "cosmosdb" {
     max_interval_in_seconds = each.value.consistency_policy.max_interval_in_seconds
     max_staleness_prefix    = each.value.consistency_policy.max_staleness_prefix
   }
-  cors_rule           = each.value.cors_rule
-  diagnostic_settings = each.value.diagnostic_settings
-  enable_telemetry    = var.enable_telemetry
-  geo_locations       = local.cosmosdb_secondary_regions[each.key]
-  ip_range_filter = [
-    "168.125.123.255",
-    "170.0.0.0/24",                                                                 #TODO: check 0.0.0.0 for validity
-    "0.0.0.0",                                                                      #Accept connections from within public Azure datacenters. https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall#allow-requests-from-the-azure-portal
-    "104.42.195.92", "40.76.54.131", "52.176.6.30", "52.169.50.45", "52.187.184.26" #Allow access from the Azure portal. https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall#allow-requests-from-global-azure-datacenters-or-other-sources-within-azure
-  ]
+  cors_rule                             = each.value.cors_rule
+  diagnostic_settings                   = each.value.diagnostic_settings
+  enable_telemetry                      = var.enable_telemetry
+  geo_locations                         = local.cosmosdb_secondary_regions[each.key]
+  ip_range_filter                       = each.value.ip_range_filter
   local_authentication_disabled         = each.value.local_authentication_disabled
   multiple_write_locations_enabled      = each.value.multiple_write_locations_enabled
-  network_acl_bypass_for_azure_services = true
+  network_acl_bypass_for_azure_services = each.value.network_acl_bypass_for_azure_services
+  network_acl_bypass_resource_ids       = each.value.network_acl_bypass_resource_ids
   partition_merge_enabled               = each.value.partition_merge_enabled
   private_endpoints = var.create_private_endpoints ? {
     "sql" = {
@@ -128,4 +116,5 @@ module "cosmosdb" {
   public_network_access_enabled           = each.value.public_network_access_enabled
   role_assignments                        = each.value.role_assignments
   tags                                    = merge(var.tags, each.value.tags)
+  virtual_network_rules                   = each.value.virtual_network_rules
 }

--- a/variables.byor.tf
+++ b/variables.byor.tf
@@ -15,13 +15,18 @@ variable "ai_search_definition" {
       event_hub_name                           = optional(string, null)
       marketplace_partner_resource_id          = optional(string, null)
     })), {})
-    sku                          = optional(string, "standard")
-    local_authentication_enabled = optional(bool, true)
-    partition_count              = optional(number, 1)
-    replica_count                = optional(number, 2)
-    semantic_search              = optional(string, "disabled")
-    hosting_mode                 = optional(string, "default")
-    tags                         = optional(map(string), {})
+    sku                           = optional(string, "standard")
+    local_authentication_enabled  = optional(bool, true)
+    partition_count               = optional(number, 1)
+    replica_count                 = optional(number, 2)
+    semantic_search               = optional(string, "disabled")
+    hosting_mode                  = optional(string, "default")
+    public_network_access_enabled = optional(bool, null)
+    network_rule_set = optional(object({
+      bypass   = optional(string, "None")
+      ip_rules = optional(list(string), [])
+    }), {})
+    tags = optional(map(string), {})
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
@@ -49,6 +54,10 @@ Configuration object for the Azure AI Search service to be created as part of th
   - `replica_count` - (Optional) The number of replicas for the search service. Default is 2.
   - `semantic_search` - (Optional) The semantic search tier. Possible values are "disabled", "free", or "standard". Default is "disabled".
   - `hosting_mode` - (Optional) The hosting mode for the search service. Default is "default".
+  - `public_network_access_enabled` - (Optional) Overrides public network access on the search service. Default is null, in which case the value is derived from `create_private_endpoints` (disabled when private endpoints are created, enabled otherwise).
+  - `network_rule_set` - (Optional) Inbound network rules applied to the search service. Only takes effect when public network access is enabled.
+    - `bypass` - (Optional) Whether trusted Azure services may bypass the rules. Possible values are "None" and "AzureServices". Default is "None".
+    - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed inbound access. Default is [].
   - `tags` - (Optional) Map of tags to assign to the AI Search service.
   - `role_assignments` - (Optional) Map of role assignments to create on the AI Search service. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
     - `role_definition_id_or_name` - The role definition ID or name to assign.
@@ -91,6 +100,18 @@ variable "cosmosdb_definition" {
     local_authentication_disabled    = optional(bool, true)
     partition_merge_enabled          = optional(bool, false)
     multiple_write_locations_enabled = optional(bool, false)
+    # Default allowlist is the Azure portal plus global Azure datacenter source IPs: https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall
+    ip_range_filter = optional(set(string), [
+      "168.125.123.255",
+      "170.0.0.0/24",
+      "0.0.0.0",
+      "104.42.195.92", "40.76.54.131", "52.176.6.30", "52.169.50.45", "52.187.184.26"
+    ])
+    network_acl_bypass_for_azure_services = optional(bool, true)
+    network_acl_bypass_resource_ids       = optional(set(string), [])
+    virtual_network_rules = optional(set(object({
+      subnet_id = string
+    })), [])
     analytical_storage_config = optional(object({
       schema_type = string
     }), null)
@@ -150,6 +171,11 @@ Configuration object for the Azure Cosmos DB account to be created for GenAI ser
   - `local_authentication_disabled` - (Optional) Whether local authentication is disabled. Default is true.
   - `partition_merge_enabled` - (Optional) Whether partition merge is enabled. Default is false.
   - `multiple_write_locations_enabled` - (Optional) Whether multiple write locations are enabled. Default is false.
+  - `ip_range_filter` - (Optional) Set of IP addresses or CIDR ranges allowed to reach the Cosmos DB account. Defaults to the Azure portal and global Azure datacenter source IPs documented at https://learn.microsoft.com/azure/cosmos-db/how-to-configure-firewall. Set to `[]` to remove the allowlist.
+  - `network_acl_bypass_for_azure_services` - (Optional) Whether Azure services can bypass the network ACLs. Default is true.
+  - `network_acl_bypass_resource_ids` - (Optional) Set of resource IDs allowed to bypass the network ACLs. Default is [].
+  - `virtual_network_rules` - (Optional) Set of subnets allowed to reach the Cosmos DB account. Default is [].
+    - `subnet_id` - The resource ID of the subnet to allow.
   - `analytical_storage_config` - (Optional) Analytical storage configuration.
     - `schema_type` - The schema type for analytical storage.
   - `consistency_policy` - (Optional) Consistency policy configuration.
@@ -202,8 +228,15 @@ variable "key_vault_definition" {
       event_hub_name                           = optional(string, null)
       marketplace_partner_resource_id          = optional(string, null)
     })), {})
-    sku       = optional(string, "standard")
-    tenant_id = optional(string)
+    sku                           = optional(string, "standard")
+    tenant_id                     = optional(string)
+    public_network_access_enabled = optional(bool, null)
+    network_acls = optional(object({
+      bypass                     = optional(string, "AzureServices")
+      default_action             = optional(string, "Allow")
+      ip_rules                   = optional(list(string), [])
+      virtual_network_subnet_ids = optional(list(string), [])
+    }), {})
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
@@ -227,6 +260,12 @@ Configuration object for the Azure Key Vault to be created for GenAI services.
   - `diagnostic_settings` - (Optional) A map of diagnostic settings to create. Each entry follows the AVM diagnostic_settings interface.
   - `sku` - (Optional) The SKU of the Key Vault. Default is "standard".
   - `tenant_id` - (Optional) The tenant ID for the Key Vault. If not provided, the current tenant will be used.
+  - `public_network_access_enabled` - (Optional) Overrides public network access on the Key Vault. Default is null, in which case the value is derived from `create_private_endpoints` (disabled when private endpoints are created, enabled otherwise).
+  - `network_acls` - (Optional) Network access control list applied to the Key Vault. Defaults to allowing all networks with an `AzureServices` bypass, which preserves the module's previous behaviour.
+    - `bypass` - (Optional) Traffic permitted to bypass the rules. Possible values are "AzureServices" and "None". Default is "AzureServices".
+    - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Allow".
+    - `ip_rules` - (Optional) List of IPv4 addresses or CIDR ranges allowed access. Default is [].
+    - `virtual_network_subnet_ids` - (Optional) List of subnet resource IDs allowed access. Default is [].
   - `role_assignments` - (Optional) Map of role assignments to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
     - `role_definition_id_or_name` - The role definition ID or name to assign.
     - `principal_id` - The principal ID to assign the role to.
@@ -267,8 +306,19 @@ variable "storage_account_definition" {
         type = "blob"
       }
     })
-    access_tier               = optional(string, "Hot")
-    shared_access_key_enabled = optional(bool, false)
+    access_tier                   = optional(string, "Hot")
+    shared_access_key_enabled     = optional(bool, false)
+    public_network_access_enabled = optional(bool, null)
+    network_rules = optional(object({
+      bypass                     = optional(set(string), ["AzureServices"])
+      default_action             = optional(string, "Deny")
+      ip_rules                   = optional(set(string), [])
+      virtual_network_subnet_ids = optional(set(string), [])
+      private_link_access = optional(list(object({
+        endpoint_resource_id = string
+        endpoint_tenant_id   = optional(string)
+      })), null)
+    }), null)
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
@@ -300,6 +350,15 @@ Configuration object for the Azure Storage Account to be created for GenAI servi
     - `private_dns_zone_resource_id` - (Optional) The resource ID of the existing private DNS zone for the endpoint. If not provided or set to null, no DNS zone group will be created.
   - `access_tier` - (Optional) The access tier for the storage account. Default is "Hot".
   - `shared_access_key_enabled` - (Optional) Whether shared access keys are enabled. Default is false.
+  - `public_network_access_enabled` - (Optional) Overrides public network access on the Storage Account. Default is null, in which case the value is derived from `create_private_endpoints` (disabled when private endpoints are created, enabled otherwise).
+  - `network_rules` - (Optional) Storage account firewall configuration. Default is null, in which case the module keeps its previous behaviour: deny-by-default with an `AzureServices` bypass when `create_private_endpoints` is true, and no network rules at all when it is false.
+    - `bypass` - (Optional) Traffic permitted to bypass the rules. Any combination of "Logging", "Metrics", "AzureServices" or "None". Default is ["AzureServices"].
+    - `default_action` - (Optional) Action taken when no rule matches. Possible values are "Allow" and "Deny". Default is "Deny".
+    - `ip_rules` - (Optional) Set of public IPv4 addresses or CIDR ranges allowed access. RFC 1918 private ranges are not permitted by Azure. Default is [].
+    - `virtual_network_subnet_ids` - (Optional) Set of subnet resource IDs allowed access. Default is [].
+    - `private_link_access` - (Optional) List of resource access rules granting private link access. Default is null.
+      - `endpoint_resource_id` - The resource ID granted access.
+      - `endpoint_tenant_id` - (Optional) The tenant ID of the resource. Defaults to the current tenant.
   - `role_assignments` - (Optional) Map of role assignments to create on the Storage Account. The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
     - `role_definition_id_or_name` - The role definition ID or name to assign.
     - `principal_id` - The principal ID to assign the role to.


### PR DESCRIPTION
## Summary

The BYOR resources hardcoded their network configuration, so consumers had no way to express an IP allowlist through module inputs. The workaround was to apply `azapi_update_resource` patches out of band after `apply`, which makes runs non-idempotent and moves a security control outside the module's contract.

This promotes those settings to first-class inputs on each BYOR definition.

Raised from Azure/terraform-azurerm-avm-ptn-aiml-landing-zone#143.

## What changed

| Definition | New attributes |
| --- | --- |
| `ai_search_definition` | `network_rule_set` (`bypass`, `ip_rules`), `public_network_access_enabled` |
| `cosmosdb_definition` | `ip_range_filter`, `network_acl_bypass_for_azure_services`, `network_acl_bypass_resource_ids`, `virtual_network_rules` |
| `key_vault_definition` | `network_acls` (`bypass`, `default_action`, `ip_rules`, `virtual_network_subnet_ids`), `public_network_access_enabled` |
| `storage_account_definition` | `network_rules` (`bypass`, `default_action`, `ip_rules`, `virtual_network_subnet_ids`, `private_link_access`), `public_network_access_enabled` |

Three `#TODO` comments are resolved by this change: the Key Vault "check to see if we need to support custom network ACLs" note, and the two Cosmos DB hardcoded-IP notes.

## Backward compatibility

Every default reproduces the value that was previously hardcoded or derived from `create_private_endpoints`, so existing configurations should plan unchanged:

- **Cosmos DB** — `ip_range_filter` defaults to exactly the Azure portal and global datacenter source IPs that were inlined in `main.byor.tf`; `network_acl_bypass_for_azure_services` still defaults to `true`.
- **Key Vault** — `network_acls` defaults to `Allow` with an `AzureServices` bypass, matching the previous inline object.
- **Storage** — `network_rules` defaults to `null`, which `locals.byor.tf` resolves back to the original `create_private_endpoints ? deny-with-AzureServices-bypass : null` conditional. Defaulting the attribute itself to `{}` was deliberately avoided, because that would have switched deny-by-default on for `create_private_endpoints = false` consumers.
- **AI Search** — `networkRuleSet` still emits only `{ bypass = "None" }` when no IP rules are supplied, so the ARM payload is byte-identical by default. `ipRules` is only added to the body when the list is non-empty.
- **`public_network_access_enabled`** — defaults to `null` on all three resources that previously derived it, meaning "keep deriving from `create_private_endpoints`". Setting it to a bool overrides.

## Testing

- `terraform fmt -recursive` — clean
- `terraform validate` at the module root — passes
- `terraform validate` in `examples/public`, `examples/private`, `examples/basic` — all pass
- `Invoke-AvmDocs` and `Invoke-AvmFormat` — run, `README.md` regenerated

Not run locally: the E2E suite, since it deploys real resources.

## Open question for reviewers: example coverage

I deliberately did **not** modify any example. The eight existing examples all exercise the behavior-preserving default path, which is the important regression check here, but none of them exercises a non-default allowlist.

I held off because `examples/private-byor-cmk/main.tf` carries a commented-out `# ip_rules = ["${data.http.ip.response_body}/32"]`, which reads as a deliberate decision to keep the E2E examples unrestricted. Adding a restrictive ACL to an E2E-tested example without knowing why that line was commented out seemed likely to break your pipeline.

If you would like the non-default path covered, I am happy to add it — just let me know whether you would prefer a deployer-IP allowlist (via an `http` data source, as the landing zone module's examples do) or a dedicated new example.
